### PR TITLE
Make ScalaBuff compiler work with windows paths as well.

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -4,6 +4,7 @@ import annotation.tailrec
 import collection.mutable
 import net.sandrogrzicic.scalabuff.compiler.FieldTypes._
 import com.google.protobuf._
+import java.io.File
 
 /**
  * Scala class generator.
@@ -447,7 +448,7 @@ class Generator protected (sourceName: String) {
       .append("\t}\n\n")
       .append("}\n")
 
-    ScalaClass(output.mkString, packageName.replace('.', '/') + '/', className)
+    ScalaClass(output.mkString, packageName.replace('.', File.separatorChar) + File.separatorChar, className)
   }
 
 }
@@ -588,8 +589,8 @@ object Generator {
  * A generated Scala class. The path is relative.
  */
 case class ScalaClass(body: String, path: String, file: String) {
-  assert(path.endsWith("/"), "path must end with a /")
-  assert(!file.contains("/"), "file name must not contain a /")
+  assert(path.endsWith(File.separator), "path must end with a " + File.separator)
+  assert(!file.contains(File.separator), "file name must not contain a " + File.separator)
 }
 
 /**

--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
@@ -32,7 +32,7 @@ object ScalaBuff {
 	def fromResourcePath(resourcePath: String, encoding: Charset = defaultCharset): ScalaClass = {
 		val reader = read(resourcePath, encoding)
 		try {
-			Generator(Parser(reader), resourcePath.dropUntilLast('/'))
+			Generator(Parser(reader), resourcePath.dropUntilLast(File.separatorChar))
 		} finally {
 			reader.close()
 		}


### PR DESCRIPTION
Hi,
We've started using ScalaBuff in one part of the Akka project, and we need it to work on windows as well.

It would be great if you could release a 1.1.3 version with these changes.
