### PR TITLE
Corrected nested Enum generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+project/target
+scalabuff-compiler/bin
+scalabuff-runtime/target
+scalabuff-runtime/doc
+scalabuff-runtime/bin
+scalabuff-compiler/target
+scalabuff-compiler/doc
+.cache

--- a/project/ScalaBuffBuild.scala
+++ b/project/ScalaBuffBuild.scala
@@ -21,8 +21,8 @@ object ScalaBuffBuild extends Build {
 	lazy val buildSettings = Seq(
 		name := "ScalaBuff",
 		organization := "net.sandrogrzicic",
-		version := "1.2.0-SNAPSHOT",
-		scalaVersion := "2.10.1",
+		version := "1.2.1-SNAPSHOT",
+		scalaVersion := "2.10.0",
 		logLevel := Level.Info
 	)
 
@@ -44,10 +44,10 @@ object ScalaBuffBuild extends Build {
 		
 		libraryDependencies ++= Seq(
 			"org.scalatest" %% "scalatest" % "1.9.1" % "test",
-			"com.google.protobuf" % "protobuf-java" % "2.4.1"
+			"com.google.protobuf" % "protobuf-java" % "2.5.0"
 		),
 
-		crossScalaVersions ++= Seq("2.9.3", "2.10.1"),
+		crossScalaVersions ++= Seq("2.9.1", "2.9.2", "2.9.3", "2.10.0"),
 
 		scalacOptions ++= Seq("-encoding", "utf8", "-unchecked", "-deprecation", "-Xlint"),
 		javacOptions ++= Seq("-encoding", "utf8", "-Xlint:unchecked", "-Xlint:deprecation"),

--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -524,6 +524,7 @@ object Generator {
   /** Prepend parent class names to all nested custom field types. */
   protected def prependParentClassNames(tree: List[Node], nestedMessageTypes: Map[Message, List[String]]) {
     val processedFieldTypes = new mutable.HashSet[FieldTypes.EnumVal]()
+    val processedEnums = new mutable.HashSet[FieldTypes.EnumVal]()
 
     for (node <- tree) node match {
       case parent @ Message(parentName, parentBody) =>
@@ -547,10 +548,11 @@ object Generator {
         // prepend parent class names to all nested enums
         parentBody.enums.foreach {
           case EnumStatement(eName, eConstants, eOptions) => {
-            for (field <- parentBody.fields.withFilter(_.fType.isEnum)) {
+            for (field <- parentBody.fields.withFilter( f => f.fType.isEnum && !processedEnums(f.fType))) {
               val fType = field.fType
               fType.scalaType = parentName + "." + fType.scalaType
               fType.defaultValue = fType.scalaType.replace(".EnumVal", "") + "._UNINITIALIZED"
+              processedEnums += fType
             }
           }
         }


### PR DESCRIPTION
I was using the scalabuff-compiler, and found that for certain .proto files, the parent class was being prepended multiple times, resulting in non-compiling code. 

I've added a small patch to Generator.scala to fix this, and also bumped the version of protobuf-java to 2.5.0.

Thanks
