### PR TITLE
fix error cases for -I and --proto_path

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
@@ -139,13 +139,13 @@ object ScalaBuff {
         val dir = s.substring("-I".length)
         val importDir = new File(dir)
         if (!importDir.isDirectory) Strings.INVALID_IMPORT_DIRECTORY + dir
-        settings.copy(importDirectories = settings.importDirectories :+ importDir)
+        else settings.copy(importDirectories = settings.importDirectories :+ importDir)
 
       case s if s startsWith "--proto_path=" =>
         val dir = s.substring("--proto_path=".length)
         val importDir = new File(dir)
         if (!importDir.isDirectory) Strings.INVALID_IMPORT_DIRECTORY + dir
-        settings.copy(importDirectories = settings.importDirectories :+ importDir)
+        else settings.copy(importDirectories = settings.importDirectories :+ importDir)
 
       case s if s startsWith "--scala_out=" =>
         val dir = s.substring("--scala_out=".length)


### PR DESCRIPTION
if you use "-I(folder that doesn't exist yet)", scalabuff will exit silently. this fixes the missing "else" to make it print a warning and continue. i also fixed the same bug in --proto_path while i was in there.
