### PR TITLE
Improvements to message creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ scalabuff-runtime/bin
 scalabuff-compiler/target
 scalabuff-compiler/doc
 .cache
+project/project
+scalabuff-compiler/project/target
+.idea
+.idea_modules

--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -344,6 +344,13 @@ class Generator protected (sourceName: String) {
 
       out.append("\n")
 
+      // apply
+      out
+          .append(indent1).append("def apply(message: Array[Byte]): ").append(name).append(" = defaultInstance.mergeFrom(message)\n")
+          .append(indent1).append("def apply(message: com.google.protobuf.ByteString): ").append(name).append(" = defaultInstance.mergeFrom(message)\n")
+
+      out.append("\n")
+
       // newBuilder
       out
           .append(indent1).append("def newBuilder = defaultInstance.newBuilderForType\n")

--- a/scalabuff-compiler/src/test/resources/generated/Complex.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Complex.scala
@@ -120,6 +120,9 @@ object ComplexMessage {
 	val REPEATED_STRING_FIELD_FIELD_NUMBER = 5
 	val REPEATED_BYTES_FIELD_FIELD_NUMBER = 6
 
+	def apply(message: Array[Byte]): ComplexMessage = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): ComplexMessage = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: ComplexMessage) = defaultInstance.mergeFrom(prototype)
 
@@ -205,6 +208,9 @@ object ComplexMessage {
 		val NESTED_FIELD_FIELD_NUMBER = 1
 		val NESTED_ENUM_FIELD_NUMBER = 2
 
+		def apply(message: Array[Byte]): Nested = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Nested = defaultInstance.mergeFrom(message)
+
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Nested) = defaultInstance.mergeFrom(prototype)
 
@@ -272,6 +278,9 @@ object AnotherMessage {
 
 	val FIELD_NESTED_FIELD_NUMBER = 1
 	val FIELD_ENUM_FIELD_NUMBER = 2
+
+	def apply(message: Array[Byte]): AnotherMessage = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): AnotherMessage = defaultInstance.mergeFrom(message)
 
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: AnotherMessage) = defaultInstance.mergeFrom(prototype)

--- a/scalabuff-compiler/src/test/resources/generated/DataTypes.scala
+++ b/scalabuff-compiler/src/test/resources/generated/DataTypes.scala
@@ -232,6 +232,9 @@ object DataTypes {
 	val F32BIT2_FIELD_NUMBER = 501
 	val F32BIT3_FIELD_NUMBER = 502
 
+	def apply(message: Array[Byte]): DataTypes = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): DataTypes = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: DataTypes) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/Dh_complex.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Dh_complex.scala
@@ -63,6 +63,9 @@ object Response {
 
 	val RESPONSE_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): Response = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): Response = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: Response) = defaultInstance.mergeFrom(prototype)
 
@@ -146,6 +149,9 @@ object Response {
 		val DATA_FIELD_NUMBER = 2
 		val PROPERTY_FIELD_NUMBER = 3
 
+		def apply(message: Array[Byte]): Rendition = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Rendition = defaultInstance.mergeFrom(message)
+
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Rendition) = defaultInstance.mergeFrom(prototype)
 
@@ -211,6 +217,9 @@ object Response {
 
 			val KEY_FIELD_NUMBER = 1
 			val VALUE_FIELD_NUMBER = 2
+
+			def apply(message: Array[Byte]): Property = defaultInstance.mergeFrom(message)
+			def apply(message: com.google.protobuf.ByteString): Property = defaultInstance.mergeFrom(message)
 
 			def newBuilder = defaultInstance.newBuilderForType
 			def newBuilder(prototype: Property) = defaultInstance.mergeFrom(prototype)
@@ -333,6 +342,9 @@ object Response {
 		val DURATION_FIELD_NUMBER = 3
 		val RENDITIONS_FIELD_NUMBER = 4
 
+		def apply(message: Array[Byte]): Video = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Video = defaultInstance.mergeFrom(message)
+
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Video) = defaultInstance.mergeFrom(prototype)
 
@@ -416,6 +428,9 @@ object Response {
 		val ASSET_KEY_FIELD_NUMBER = 1
 		val REASON_FIELD_NUMBER = 2
 		val CAUSE_FIELD_NUMBER = 3
+
+		def apply(message: Array[Byte]): VideoFailure = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): VideoFailure = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: VideoFailure) = defaultInstance.mergeFrom(prototype)
@@ -522,6 +537,9 @@ object Response {
 
 		val SUCCESS_FIELD_NUMBER = 1
 		val FAILURE_FIELD_NUMBER = 2
+
+		def apply(message: Array[Byte]): VideoResult = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): VideoResult = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: VideoResult) = defaultInstance.mergeFrom(prototype)

--- a/scalabuff-compiler/src/test/resources/generated/Enum.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Enum.scala
@@ -100,6 +100,9 @@ object Outer {
 	val INNER_OPTIONAL_FIELD_NUMBER = 2
 	val INNER_REPEATED_FIELD_NUMBER = 3
 
+	def apply(message: Array[Byte]): Outer = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): Outer = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: Outer) = defaultInstance.mergeFrom(prototype)
 
@@ -202,6 +205,9 @@ object OuterDuplicate {
 	val INNER_OPTIONAL_FIELD_NUMBER = 2
 	val INNER_REPEATED_FIELD_NUMBER = 3
 
+	def apply(message: Array[Byte]): OuterDuplicate = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): OuterDuplicate = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: OuterDuplicate) = defaultInstance.mergeFrom(prototype)
 
@@ -281,6 +287,9 @@ object OuterEnumContainer {
 
 	val INNER_MESSAGE_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): OuterEnumContainer = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): OuterEnumContainer = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: OuterEnumContainer) = defaultInstance.mergeFrom(prototype)
 
@@ -338,6 +347,9 @@ object OuterEnumContainer {
 		@reflect.BeanProperty val defaultInstance = new InnerEnumContainer()
 
 		val SOME_ENUM_FIELD_NUMBER = 1
+
+		def apply(message: Array[Byte]): InnerEnumContainer = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): InnerEnumContainer = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: InnerEnumContainer) = defaultInstance.mergeFrom(prototype)

--- a/scalabuff-compiler/src/test/resources/generated/Extensions.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Extensions.scala
@@ -57,6 +57,9 @@ object ExtensionsTest {
 
 	val FOO_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): ExtensionsTest = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): ExtensionsTest = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: ExtensionsTest) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/Groups.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Groups.scala
@@ -53,6 +53,9 @@ object Groups {
 	@reflect.BeanProperty val defaultInstance = new Groups()
 
 
+	def apply(message: Array[Byte]): Groups = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): Groups = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: Groups) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/Imports.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Imports.scala
@@ -60,6 +60,9 @@ object UsesImport {
 
 	val SIMPLE_TEST_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): UsesImport = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): UsesImport = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: UsesImport) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/Message.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Message.scala
@@ -53,6 +53,9 @@ object EmptyMessage {
 	@reflect.BeanProperty val defaultInstance = new EmptyMessage()
 
 
+	def apply(message: Array[Byte]): EmptyMessage = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): EmptyMessage = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: EmptyMessage) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
@@ -53,6 +53,9 @@ object MutiMessageOne {
 	@reflect.BeanProperty val defaultInstance = new MutiMessageOne()
 
 
+	def apply(message: Array[Byte]): MutiMessageOne = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): MutiMessageOne = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: MutiMessageOne) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
@@ -111,6 +111,9 @@ object MultiMessageTwo {
 	val INT32DEFAULT_FIELD_NUMBER = 5
 	val STRINGDEFAULT_FIELD_NUMBER = 6
 
+	def apply(message: Array[Byte]): MultiMessageTwo = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): MultiMessageTwo = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: MultiMessageTwo) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/NestedMessages.scala
+++ b/scalabuff-compiler/src/test/resources/generated/NestedMessages.scala
@@ -56,6 +56,9 @@ object TopLevel {
 
 	val ID_TOPLEVEL_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): TopLevel = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): TopLevel = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: TopLevel) = defaultInstance.mergeFrom(prototype)
 
@@ -113,6 +116,9 @@ object TopLevel {
 		@reflect.BeanProperty val defaultInstance = new Inner()
 
 		val ID_INNER_FIELD_NUMBER = 1
+
+		def apply(message: Array[Byte]): Inner = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Inner = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Inner) = defaultInstance.mergeFrom(prototype)
@@ -268,6 +274,9 @@ object Foobar {
 	val TOP_LEVEL_OPT_FIELD_NUMBER = 8
 	val TOP_LEVEL_INNER_REQ_FIELD_NUMBER = 9
 
+	def apply(message: Array[Byte]): Foobar = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): Foobar = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: Foobar) = defaultInstance.mergeFrom(prototype)
 
@@ -327,6 +336,9 @@ object Foobar {
 		@reflect.BeanProperty val defaultInstance = new Foo()
 
 		val ID_FIELD_NUMBER = 1
+
+		def apply(message: Array[Byte]): Foo = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Foo = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Foo) = defaultInstance.mergeFrom(prototype)
@@ -389,6 +401,9 @@ object Foobar {
 
 		val ID_FIELD_NUMBER = 1
 
+		def apply(message: Array[Byte]): Bar = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): Bar = defaultInstance.mergeFrom(message)
+
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: Bar) = defaultInstance.mergeFrom(prototype)
 
@@ -449,6 +464,9 @@ object Foobar {
 		@reflect.BeanProperty val defaultInstance = new FooBar()
 
 		val ID_FIELD_NUMBER = 1
+
+		def apply(message: Array[Byte]): FooBar = defaultInstance.mergeFrom(message)
+		def apply(message: com.google.protobuf.ByteString): FooBar = defaultInstance.mergeFrom(message)
 
 		def newBuilder = defaultInstance.newBuilderForType
 		def newBuilder(prototype: FooBar) = defaultInstance.mergeFrom(prototype)

--- a/scalabuff-compiler/src/test/resources/generated/Numbers.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Numbers.scala
@@ -70,6 +70,9 @@ object NumbersTest1 {
 	val SOME_HEX_NUMBER_FIELD_NUMBER = 1
 	val SOME_OCT_NUMBER_FIELD_NUMBER = 2
 
+	def apply(message: Array[Byte]): NumbersTest1 = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): NumbersTest1 = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: NumbersTest1) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/RemoteProtocol.scala
+++ b/scalabuff-compiler/src/test/resources/generated/RemoteProtocol.scala
@@ -76,6 +76,9 @@ object AkkaRemoteProtocol {
 	val MESSAGE_FIELD_NUMBER = 1
 	val INSTRUCTION_FIELD_NUMBER = 2
 
+	def apply(message: Array[Byte]): AkkaRemoteProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): AkkaRemoteProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: AkkaRemoteProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -169,6 +172,9 @@ object RemoteMessageProtocol {
 	val SENDER_FIELD_NUMBER = 4
 	val METADATA_FIELD_NUMBER = 5
 
+	def apply(message: Array[Byte]): RemoteMessageProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): RemoteMessageProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: RemoteMessageProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -251,6 +257,9 @@ object RemoteControlProtocol {
 	val COOKIE_FIELD_NUMBER = 2
 	val ORIGIN_FIELD_NUMBER = 3
 
+	def apply(message: Array[Byte]): RemoteControlProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): RemoteControlProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: RemoteControlProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -332,6 +341,9 @@ object ActorRefProtocol {
 
 	val PATH_FIELD_NUMBER = 1
 
+	def apply(message: Array[Byte]): ActorRefProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): ActorRefProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: ActorRefProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -409,6 +421,9 @@ object MessageProtocol {
 	val SERIALIZERID_FIELD_NUMBER = 2
 	val MESSAGEMANIFEST_FIELD_NUMBER = 3
 
+	def apply(message: Array[Byte]): MessageProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): MessageProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: MessageProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -475,6 +490,9 @@ object MetadataEntryProtocol {
 
 	val KEY_FIELD_NUMBER = 1
 	val VALUE_FIELD_NUMBER = 2
+
+	def apply(message: Array[Byte]): MetadataEntryProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): MetadataEntryProtocol = defaultInstance.mergeFrom(message)
 
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: MetadataEntryProtocol) = defaultInstance.mergeFrom(prototype)
@@ -550,6 +568,9 @@ object AddressProtocol {
 	val SYSTEM_FIELD_NUMBER = 1
 	val HOSTNAME_FIELD_NUMBER = 2
 	val PORT_FIELD_NUMBER = 3
+
+	def apply(message: Array[Byte]): AddressProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): AddressProtocol = defaultInstance.mergeFrom(message)
 
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: AddressProtocol) = defaultInstance.mergeFrom(prototype)
@@ -633,6 +654,9 @@ object DaemonMsgCreateProtocol {
 	val DEPLOY_FIELD_NUMBER = 2
 	val PATH_FIELD_NUMBER = 3
 	val SUPERVISOR_FIELD_NUMBER = 4
+
+	def apply(message: Array[Byte]): DaemonMsgCreateProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): DaemonMsgCreateProtocol = defaultInstance.mergeFrom(message)
 
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: DaemonMsgCreateProtocol) = defaultInstance.mergeFrom(prototype)
@@ -731,6 +755,9 @@ object PropsProtocol {
 	val CREATOR_FIELD_NUMBER = 4
 	val ROUTERCONFIG_FIELD_NUMBER = 5
 
+	def apply(message: Array[Byte]): PropsProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): PropsProtocol = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: PropsProtocol) = defaultInstance.mergeFrom(prototype)
 
@@ -819,6 +846,9 @@ object DeployProtocol {
 	val CONFIG_FIELD_NUMBER = 2
 	val ROUTERCONFIG_FIELD_NUMBER = 3
 	val SCOPE_FIELD_NUMBER = 4
+
+	def apply(message: Array[Byte]): DeployProtocol = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): DeployProtocol = defaultInstance.mergeFrom(message)
 
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: DeployProtocol) = defaultInstance.mergeFrom(prototype)

--- a/scalabuff-compiler/src/test/resources/generated/Simple.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Simple.scala
@@ -141,6 +141,9 @@ object SimpleTest {
 	val FLOATDEFAULT_FIELD_NUMBER = 8
 	val FLOATNEGATIVE_FIELD_NUMBER = 9
 
+	def apply(message: Array[Byte]): SimpleTest = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): SimpleTest = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: SimpleTest) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/resources/generated/SimpleWithComments.scala
+++ b/scalabuff-compiler/src/test/resources/generated/SimpleWithComments.scala
@@ -78,6 +78,9 @@ object SimpleRequest {
 	val PAGE_NUMBER_FIELD_NUMBER = 2
 	val RESULTS_PER_PAGE_FIELD_NUMBER = 3
 
+	def apply(message: Array[Byte]): SimpleRequest = defaultInstance.mergeFrom(message)
+	def apply(message: com.google.protobuf.ByteString): SimpleRequest = defaultInstance.mergeFrom(message)
+
 	def newBuilder = defaultInstance.newBuilderForType
 	def newBuilder(prototype: SimpleRequest) = defaultInstance.mergeFrom(prototype)
 

--- a/scalabuff-compiler/src/test/tests/MessageTest.scala
+++ b/scalabuff-compiler/src/test/tests/MessageTest.scala
@@ -33,7 +33,7 @@ class MessageTest extends FunSuite with ShouldMatchers {
 		sent.repeatedStringField should equal (repeatedString)
 		sent.repeatedBytesField should equal (repeatedBytes)
 
-		val received = ComplexMessage.defaultInstance.mergeFrom(sent.toByteArray)
+		val received = ComplexMessage(sent.toByteArray)
 
 		received.firstField should equal(sent.firstField)
 		received.secondField should equal(sent.secondField)


### PR DESCRIPTION
Following a request from one of our developers for the ability to create messages in a more "Scala-y" way...

Add apply methods to companion object to allow "Foo(array)", obviating the necessity for "Foo.defaultInstance.mergeFrom(array)"
.gitignore updates for Idea developers
Update test resources
