### PR TITLE
i think the compiler depends on the runtime always...

### DIFF
--- a/project/ScalaBuffBuild.scala
+++ b/project/ScalaBuffBuild.scala
@@ -76,7 +76,7 @@ object ScalaBuffBuild extends Build {
 	lazy val compiler = Project(
 		id = "scalabuff-compiler",
 		base = file("scalabuff-compiler"),
-		dependencies = Seq(runtime % "test->compile"),
+		dependencies = Seq(runtime),
 		settings = defaultSettings ++ Seq(
 			mainClass in (Compile, run) := Some("net.sandrogrzicic.scalabuff.compiler.ScalaBuff"),
 			mainClass in (Compile, packageBin) := Some("net.sandrogrzicic.scalabuff.compiler.ScalaBuff"),


### PR DESCRIPTION
a coworker noticed that the runtime is required any time you use the compiler. (he's trying to integrate scalabuff into our gradle-based build system.) is there any reason not to simplify the dependency?
