### PR TITLE
fix parsing of optional parameters.

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Parser.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Parser.scala
@@ -48,7 +48,7 @@ class Parser(val inputName: String) extends RegexParsers with PackratParsers {
   }
 
   lazy val option: PackratParser[OptionValue] = "option" ~> optionBody <~ ";"
-  lazy val optionBody: PackratParser[OptionValue] = (("(" ?) ~> identifier ~ (("." ~ identifier) *) <~ (")" ?)) ~ ("=" ~> constant) ^^ {
+  lazy val optionBody: PackratParser[OptionValue] = (("(" ?) ~> identifier ~> (")" ?) ~ (("." ~ identifier) *)) ~ ("=" ~> constant) ^^ {
 		case ident ~ idents ~ value => OptionValue(ident + idents.map(i => i._1 + i._2).mkString, value)
   }
 


### PR DESCRIPTION
Without this change the following (valid) protobuf snippet will not compile:

import "nanopb.proto";

// This message is used by the client to upload sample data to the server.
// It is unacknowledged to save bandwidth.
message SensorSample {
    // sampleType is usually a single character string.
    required string sensor = 1 [(nanopb).max_size = 32];
}
