### PR TITLE
fix error where messages were imported into the current namespace

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -620,8 +620,11 @@ object Generator {
           body.fields.foreach { field =>
             val scalaType = if (field.fType.scalaType endsWith ".EnumVal") field.fType.scalaType.split("\\.")(0) else field.fType.scalaType
             importedSymbols.get(scalaType).foreach { symbol =>
-              field.fType.scalaType = symbol.packageName + "." + field.fType.scalaType
-              field.fType.defaultValue = symbol.packageName + "." + field.fType.defaultValue
+	      // Namespaces might be empty for imported message types
+	      val namespacePrefix = if(symbol.packageName.isEmpty) "" else symbol.packageName + "."
+
+              field.fType.scalaType = namespacePrefix + field.fType.scalaType
+              field.fType.defaultValue = namespacePrefix + field.fType.defaultValue
             }
           }
         case _ =>


### PR DESCRIPTION
Without this change emitted Enum names would look like ".Foo" rather
than "Foo" if the imports were done into the current namespace.
