### PR TITLE
Support for easy JSON generation (via for example) Spray JSON

### DIFF
--- a/project/ScalaBuffBuild.scala
+++ b/project/ScalaBuffBuild.scala
@@ -66,7 +66,7 @@ object ScalaBuffBuild extends Build {
 		javaSource in Compile <<= baseDirectory(_ / "src/main"),
 		javaSource in Test <<= baseDirectory(_ / "src/test"),
 
-		docDirectory in Compile <<= baseDirectory(_ / "doc"),
+		target in Compile in doc <<= baseDirectory(_ / "doc"),
 
 		compileOrder := CompileOrder.Mixed,
 		

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.5.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.6.0")

--- a/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
+++ b/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
@@ -56,6 +56,7 @@ final case class UsesImportPackage (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
+	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
 }
 
 object UsesImportPackage {

--- a/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
@@ -50,6 +50,7 @@ final case class MutiMessageOne (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
+	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
 }
 
 object MutiMessageOne {

--- a/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
@@ -102,6 +102,7 @@ final case class MultiMessageTwo (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
+	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
 }
 
 object MultiMessageTwo {

--- a/scalabuff-compiler/src/test/resources/generated/Simple.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Simple.scala
@@ -129,6 +129,7 @@ final case class SimpleTest (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
+	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
 }
 
 object SimpleTest {

--- a/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
+++ b/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
@@ -54,6 +54,7 @@ final case class PackageTest (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
+	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
 }
 
 object PackageTest {

--- a/scalabuff-runtime/src/main/net/sandrogrzicic/scalabuff/Parser.scala
+++ b/scalabuff-runtime/src/main/net/sandrogrzicic/scalabuff/Parser.scala
@@ -10,8 +10,8 @@ import java.io.InputStream
  * @author Sandro Gržičić
  */
 trait Parser[MessageType <: MessageLite] extends com.google.protobuf.Parser[MessageType] {
-  final val EMPTY_REGISTRY = ExtensionRegistryLite.getEmptyRegistry
-
+  import Parser.EMPTY_REGISTRY
+  
   private def checkMessageInitialized(message: MessageType): MessageType = {
     if (message != null && !message.isInitialized) {
       throw new UninitializedMessageException(message)
@@ -157,3 +157,6 @@ trait Parser[MessageType <: MessageLite] extends com.google.protobuf.Parser[Mess
   }
 }
 
+object Parser {
+  final val EMPTY_REGISTRY = ExtensionRegistryLite.getEmptyRegistry
+}


### PR DESCRIPTION
I am using ScalaBuff in a [Spray](http://spray.io) project where I output instances not just as Protobuf but also in JSON format. For this, I use [Spray JSON](https://github.com/spray/spray-json), which directly supports case classes – as long as they do not contain additional fields (i.e., fields that are declared in the case class body and not just in the constructor).

Unfortunately, `Parser` [has](https://github.com/SandroGrzicic/ScalaBuff/blob/9322a213ebc383d3deed6d291b3b956420983264/scalabuff-runtime/src/main/net/sandrogrzicic/scalabuff/Parser.scala) such a field: `final val EMPTY_REGISTRY`. This pull request proposes to make the field static by moving it to `object Parser`.
