### PR TITLE
Generate fully qualified names for Scala's collection classes. 

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -127,7 +127,7 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
           case OPTIONAL =>
             out.append("Option[").append(field.fType.scalaType).append("] = ").append(field.defaultValue).append(",\n")
           case REPEATED =>
-            out.append("collection.immutable.Seq[").append(field.fType.scalaType).append("] = Vector.empty[").append(field.fType.scalaType).append("],\n")
+            out.append("scala.collection.immutable.Seq[").append(field.fType.scalaType).append("] = Vector.empty[").append(field.fType.scalaType).append("],\n")
           case _ => // "missing combination <local child>"
         }
       }
@@ -241,7 +241,7 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
             .append("var ").append(field.name.toTemporaryIdent).append(": Option[").append(field.fType.scalaType).append("]")
             .append(" = ").append(field.name.toScalaIdent).append("\n")
           case REPEATED => out.append(indent2)
-            .append("val ").append(field.name.toTemporaryIdent).append(": collection.mutable.Buffer[").append(field.fType.scalaType).append("]")
+            .append("val ").append(field.name.toTemporaryIdent).append(": scala.collection.mutable.Buffer[").append(field.fType.scalaType).append("]")
             .append(" = ").append(field.name.toScalaIdent).append(".toBuffer\n")
           case _ => // "missing combination <local child>"
         }

--- a/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
@@ -6,7 +6,7 @@ package resources.generated
 final case class MultiMessageTwo (
 	`requiredField`: Int = 0,
 	`optionalField`: Option[Float] = None,
-	`repeatedField`: collection.immutable.Seq[String] = Vector.empty[String],
+	`repeatedField`: scala.collection.immutable.Seq[String] = Vector.empty[String],
 	`type`: Option[Int] = Some(100),
 	`int32Default`: Option[Int] = Some(100),
 	`stringDefault`: Option[String] = Some("somestring")
@@ -56,7 +56,7 @@ final case class MultiMessageTwo (
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __requiredField: Int = 0
 		var __optionalField: Option[Float] = `optionalField`
-		val __repeatedField: collection.mutable.Buffer[String] = `repeatedField`.toBuffer
+		val __repeatedField: scala.collection.mutable.Buffer[String] = `repeatedField`.toBuffer
 		var __type: Option[Int] = `type`
 		var __int32Default: Option[Int] = `int32Default`
 		var __stringDefault: Option[String] = `stringDefault`

--- a/scalabuff-compiler/src/test/resources/generated/Simple.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Simple.scala
@@ -6,7 +6,7 @@ package resources.generated
 final case class SimpleTest (
 	`requiredField`: Int = 0,
 	`optionalField`: Option[Float] = None,
-	`repeatedField`: collection.immutable.Seq[String] = Vector.empty[String],
+	`repeatedField`: scala.collection.immutable.Seq[String] = Vector.empty[String],
 	`type`: Option[Int] = Some(100),
 	`int32Default`: Option[Int] = Some(100),
 	`int32Negative`: Option[Int] = Some(-1),
@@ -71,7 +71,7 @@ final case class SimpleTest (
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __requiredField: Int = 0
 		var __optionalField: Option[Float] = `optionalField`
-		val __repeatedField: collection.mutable.Buffer[String] = `repeatedField`.toBuffer
+		val __repeatedField: scala.collection.mutable.Buffer[String] = `repeatedField`.toBuffer
 		var __type: Option[Int] = `type`
 		var __int32Default: Option[Int] = `int32Default`
 		var __int32Negative: Option[Int] = `int32Negative`


### PR DESCRIPTION
If a proto definition has a namespace that contains a child namespace called "collection", then the generated Scala files will fail to compile since it will try to look for "collection.immutable.Seq" in the child namespace and not in "scala" namespace. Fully qualifying resolves this issue.
