### PR TITLE
Add hinted deserializer support

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -540,8 +540,6 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
     if (imports.size > 0) output.append("\n")
     imports.clear()
 
-//    output.append(hintMapOutput).append("\n")
-
     // generated output
     output.append(generatedOutput).append("\n")
 


### PR DESCRIPTION
This PR adds a 

def deserializePayload(payload: Array[Byte], payloadType: String): GeneratedMessageLite

and associated support structures to the generated Scala code. This comes in handy when using protobuf as payload in a (framed) protocol and avoiding using reflection at runtime. 

I initially tried doing this with a macro which worked ok, except I couldn't find a way to enumerate the objects in the generated package (by scalabuff). I need to iterate them (protobuf messages basically) to generate a hint map. It's far simpler to achieve the same result just doing code generation as part of scalabuff. 
