### PR TITLE
Fix json generation bug

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -394,7 +394,7 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
               case _ =>
             }
           }
-        out.append(indent2).append("sb.length -= 1\n")
+        out.append(indent2).append("if(!sb.isEmpty && sb.charAt(sb.length - 1) == ',') sb.length -= 1\n")
         out.append(indent2).append("sb.append(indent0).append(\"}\")\n")
 
         out.append(indent2).append("sb.toString()\n")

--- a/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
+++ b/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
@@ -18,7 +18,7 @@ final case class UsesImportPackage (
 		output.writeMessage(1, `packageTest`)
 	}
 
-	lazy val getSerializedSize = {
+	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
 		__size += computeMessageSize(1, `packageTest`)
@@ -79,4 +79,14 @@ object ImportPackages {
 	def registerAllExtensions(registry: com.google.protobuf.ExtensionRegistryLite) {
 	}
 
+	private val fromBinaryHintMap = collection.immutable.HashMap[String, Array[Byte] ⇒ com.google.protobuf.GeneratedMessageLite](
+		 "UsesImportPackage" -> (bytes ⇒ UsesImportPackage.parseFrom(bytes))
+	)
+
+	def deserializePayload(payload: Array[Byte], payloadType: String): com.google.protobuf.GeneratedMessageLite = {
+		fromBinaryHintMap.get(payloadType) match {
+			case Some(f) ⇒ f(payload)
+			case None    ⇒ throw new IllegalArgumentException(s"unimplemented deserialization of message payload of type [${payloadType}]")
+		}
+	}
 }

--- a/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiOne.scala
@@ -15,7 +15,7 @@ final case class MutiMessageOne (
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
 	}
 
-	lazy val getSerializedSize = {
+	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
 
@@ -72,4 +72,14 @@ object MultiOne {
 	def registerAllExtensions(registry: com.google.protobuf.ExtensionRegistryLite) {
 	}
 
+	private val fromBinaryHintMap = collection.immutable.HashMap[String, Array[Byte] ⇒ com.google.protobuf.GeneratedMessageLite](
+		 "MutiMessageOne" -> (bytes ⇒ MutiMessageOne.parseFrom(bytes))
+	)
+
+	def deserializePayload(payload: Array[Byte], payloadType: String): com.google.protobuf.GeneratedMessageLite = {
+		fromBinaryHintMap.get(payloadType) match {
+			case Some(f) ⇒ f(payload)
+			case None    ⇒ throw new IllegalArgumentException(s"unimplemented deserialization of message payload of type [${payloadType}]")
+		}
+	}
 }

--- a/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
@@ -39,7 +39,7 @@ final case class MultiMessageTwo (
 		if (`stringDefault`.isDefined) output.writeString(6, `stringDefault`.get)
 	}
 
-	lazy val getSerializedSize = {
+	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
 		__size += computeInt32Size(1, `requiredField`)
@@ -130,4 +130,14 @@ object MultiTwo {
 	def registerAllExtensions(registry: com.google.protobuf.ExtensionRegistryLite) {
 	}
 
+	private val fromBinaryHintMap = collection.immutable.HashMap[String, Array[Byte] ⇒ com.google.protobuf.GeneratedMessageLite](
+		 "MultiMessageTwo" -> (bytes ⇒ MultiMessageTwo.parseFrom(bytes))
+	)
+
+	def deserializePayload(payload: Array[Byte], payloadType: String): com.google.protobuf.GeneratedMessageLite = {
+		fromBinaryHintMap.get(payloadType) match {
+			case Some(f) ⇒ f(payload)
+			case None    ⇒ throw new IllegalArgumentException(s"unimplemented deserialization of message payload of type [${payloadType}]")
+		}
+	}
 }

--- a/scalabuff-compiler/src/test/resources/generated/Simple.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Simple.scala
@@ -51,7 +51,7 @@ final case class SimpleTest (
 		if (`floatNegative`.isDefined) output.writeFloat(9, `floatNegative`.get)
 	}
 
-	lazy val getSerializedSize = {
+	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
 		__size += computeInt32Size(1, `requiredField`)
@@ -129,7 +129,26 @@ final case class SimpleTest (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
-	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
+	def toJson(indent: Int = 0): String = {
+		val indent0 = "\n" + ("\t" * indent)
+		val (indent1, indent2) = (indent0 + "\t", indent0 + "\t\t")
+		val sb = StringBuilder.newBuilder
+		sb
+			.append("{")
+			sb.append(indent1).append("\"requiredField\": ").append("\"").append(`requiredField`).append("\"").append(',')
+			if (`optionalField`.isDefined) { sb.append(indent1).append("\"optionalField\": ").append("\"").append(`optionalField`.get).append("\"").append(',') }
+			sb.append(indent1).append("\"repeatedField\": [").append(indent2).append(`repeatedField`.map("\"" + _ + "\"").mkString(", " + indent2)).append(indent1).append(']').append(',')
+			if (`type`.isDefined) { sb.append(indent1).append("\"type\": ").append("\"").append(`type`.get).append("\"").append(',') }
+			if (`int32Default`.isDefined) { sb.append(indent1).append("\"int32Default\": ").append("\"").append(`int32Default`.get).append("\"").append(',') }
+			if (`int32Negative`.isDefined) { sb.append(indent1).append("\"int32Negative\": ").append("\"").append(`int32Negative`.get).append("\"").append(',') }
+			if (`stringDefault`.isDefined) { sb.append(indent1).append("\"stringDefault\": ").append("\"").append(`stringDefault`.get).append("\"").append(',') }
+			if (`floatDefault`.isDefined) { sb.append(indent1).append("\"floatDefault\": ").append("\"").append(`floatDefault`.get).append("\"").append(',') }
+			if (`floatNegative`.isDefined) { sb.append(indent1).append("\"floatNegative\": ").append("\"").append(`floatNegative`.get).append("\"").append(',') }
+		if(!sb.isEmpty && sb.charAt(sb.length - 1) == ',') sb.length -= 1
+		sb.append(indent0).append("}")
+		sb.toString()
+	}
+
 }
 
 object SimpleTest {
@@ -160,4 +179,14 @@ object Simple {
 	def registerAllExtensions(registry: com.google.protobuf.ExtensionRegistryLite) {
 	}
 
+	private val fromBinaryHintMap = collection.immutable.HashMap[String, Array[Byte] ⇒ com.google.protobuf.GeneratedMessageLite](
+		 "SimpleTest" -> (bytes ⇒ SimpleTest.parseFrom(bytes))
+	)
+
+	def deserializePayload(payload: Array[Byte], payloadType: String): com.google.protobuf.GeneratedMessageLite = {
+		fromBinaryHintMap.get(payloadType) match {
+			case Some(f) ⇒ f(payload)
+			case None    ⇒ throw new IllegalArgumentException(s"unimplemented deserialization of message payload of type [${payloadType}]")
+		}
+	}
 }

--- a/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
+++ b/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
@@ -16,7 +16,7 @@ final case class PackageTest (
 		output.writeInt32(1, `requiredField`)
 	}
 
-	lazy val getSerializedSize = {
+	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
 		__size += computeInt32Size(1, `requiredField`)
@@ -77,4 +77,14 @@ object PackageName {
 	def registerAllExtensions(registry: com.google.protobuf.ExtensionRegistryLite) {
 	}
 
+	private val fromBinaryHintMap = collection.immutable.HashMap[String, Array[Byte] ⇒ com.google.protobuf.GeneratedMessageLite](
+		 "PackageTest" -> (bytes ⇒ PackageTest.parseFrom(bytes))
+	)
+
+	def deserializePayload(payload: Array[Byte], payloadType: String): com.google.protobuf.GeneratedMessageLite = {
+		fromBinaryHintMap.get(payloadType) match {
+			case Some(f) ⇒ f(payload)
+			case None    ⇒ throw new IllegalArgumentException(s"unimplemented deserialization of message payload of type [${payloadType}]")
+		}
+	}
 }


### PR DESCRIPTION
If a message consists entirely of optional fields and none of them are set then the message gets serialized to Json as `{` instead of `{}`.