### PR TITLE
Proper disambiguation of imports

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
@@ -101,7 +101,7 @@ object ScalaBuff {
     if (file.isAbsolute) {
       Option(file).filter(_.exists)
     } else {
-      (searchInFirst.toSeq ++ settings.importDirectories).map { folder =>
+      (searchInFirst.toSeq ++ settings.importDirectories).view.map { folder =>
         new File(folder, filename)
       }.find(_.exists)
     }


### PR DESCRIPTION
This PR fixes the following problem: 

If you happen to have 2+ sets of identically named files (with different contents) in different folders, the imports inside those work incorrectly. E.g., imagine you have 

```
/bar/msg.proto
/bar/msg2.proto
/foo/msg.proto
/foo/msg2.proto
```

and inside `foo/msg.proto` you have a line `import "msg2.proto"`, then the generated Scala code references the classes generated from `bar/msg2.proto`, just because of the alphabetic ordering in the global import table. 

I admit that the fix is a bit of a hack: it simply puts the home folder at the head of the import table for each processed file. It seems to be working without any side effects so far however.

Included is also a tiny performance optimization making the import table lazy internally.