### PR TITLE
Only use backticks for reserved/invalid identifiers

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/BuffedString.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/BuffedString.scala
@@ -6,7 +6,7 @@ package net.sandrogrzicic.scalabuff.compiler
  */
 
 class BuffedString(str: String) {
-	import BuffedString.camelCaseRegex
+	import BuffedString.{camelCaseRegex, scalaReserved}
 
 	/**
 	 * CamelCases this string, with the first letter uppercased.
@@ -14,10 +14,19 @@ class BuffedString(str: String) {
 	def camelCase = lowerCamelCase.capitalize
 
 	/**
+	 * Adds backticks for reserved keywords or names with characters like spaces, symbols etc.
+	 */
+	def quotedIdent(name: String) = {
+		if (scalaReserved(name)) '`' + name + '`'
+		else if (name.matches("[a-zA-Z_][\\w\\d_]*")) name
+		else '`' + name + '`'
+	}
+
+	/**
 	 * Generates a valid Scala identifier: 
 	 * camelCases this string, leaving the first letter lowercased and wraps it into backticks.
 	 */
-	def toScalaIdent = "`" + lowerCamelCase + "`"
+	def toScalaIdent = quotedIdent(lowerCamelCase)
 	
 	/**
 	 * camelCases this string, with the first letter lowercased.
@@ -92,4 +101,12 @@ object BuffedString {
 	def indent(indentLevel: Int) = "\t" * indentLevel
 
 	val camelCaseRegex = """_(\w)""".r
+
+	/**
+	 * Reserved scala keywords that require backticks
+	 */
+	val scalaReserved =
+		Set("type", "val", "def", "else", "if", "object",
+			"yield", "for", "import", "match", "case", "lazy",
+			"var", "class", "package", "extends")
 }

--- a/scalabuff-compiler/src/test/resources/generated/Complex.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Complex.scala
@@ -4,56 +4,56 @@
 package resources.generated
 
 final case class ComplexMessage (
-	`firstField`: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY,
-	`secondField`: Option[String] = Some("defaultValueForSecondField"),
-	`nestedOuterField`: Option[ComplexMessage.Nested] = None,
-	`simpleEnumField`: scala.collection.immutable.Seq[ComplexMessage.SimpleEnum.EnumVal] = Vector.empty[ComplexMessage.SimpleEnum.EnumVal],
-	`repeatedStringField`: scala.collection.immutable.Seq[String] = Vector.empty[String],
-	`repeatedBytesField`: scala.collection.immutable.Seq[com.google.protobuf.ByteString] = Vector.empty[com.google.protobuf.ByteString]
+	firstField: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY,
+	secondField: Option[String] = Some("defaultValueForSecondField"),
+	nestedOuterField: Option[ComplexMessage.Nested] = None,
+	simpleEnumField: scala.collection.immutable.Seq[ComplexMessage.SimpleEnum.EnumVal] = Vector.empty[ComplexMessage.SimpleEnum.EnumVal],
+	repeatedStringField: scala.collection.immutable.Seq[String] = Vector.empty[String],
+	repeatedBytesField: scala.collection.immutable.Seq[com.google.protobuf.ByteString] = Vector.empty[com.google.protobuf.ByteString]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[ComplexMessage]
 	with net.sandrogrzicic.scalabuff.Parser[ComplexMessage] {
 
-	def setSecondField(_f: String) = copy(`secondField` = Some(_f))
-	def setNestedOuterField(_f: ComplexMessage.Nested) = copy(`nestedOuterField` = Some(_f))
-	def setSimpleEnumField(_i: Int, _v: ComplexMessage.SimpleEnum.EnumVal) = copy(`simpleEnumField` = `simpleEnumField`.updated(_i, _v))
-	def addSimpleEnumField(_f: ComplexMessage.SimpleEnum.EnumVal) = copy(`simpleEnumField` = `simpleEnumField` :+ _f)
-	def addAllSimpleEnumField(_f: ComplexMessage.SimpleEnum.EnumVal*) = copy(`simpleEnumField` = `simpleEnumField` ++ _f)
-	def addAllSimpleEnumField(_f: TraversableOnce[ComplexMessage.SimpleEnum.EnumVal]) = copy(`simpleEnumField` = `simpleEnumField` ++ _f)
-	def setRepeatedStringField(_i: Int, _v: String) = copy(`repeatedStringField` = `repeatedStringField`.updated(_i, _v))
-	def addRepeatedStringField(_f: String) = copy(`repeatedStringField` = `repeatedStringField` :+ _f)
-	def addAllRepeatedStringField(_f: String*) = copy(`repeatedStringField` = `repeatedStringField` ++ _f)
-	def addAllRepeatedStringField(_f: TraversableOnce[String]) = copy(`repeatedStringField` = `repeatedStringField` ++ _f)
-	def setRepeatedBytesField(_i: Int, _v: com.google.protobuf.ByteString) = copy(`repeatedBytesField` = `repeatedBytesField`.updated(_i, _v))
-	def addRepeatedBytesField(_f: com.google.protobuf.ByteString) = copy(`repeatedBytesField` = `repeatedBytesField` :+ _f)
-	def addAllRepeatedBytesField(_f: com.google.protobuf.ByteString*) = copy(`repeatedBytesField` = `repeatedBytesField` ++ _f)
-	def addAllRepeatedBytesField(_f: TraversableOnce[com.google.protobuf.ByteString]) = copy(`repeatedBytesField` = `repeatedBytesField` ++ _f)
+	def setSecondField(_f: String) = copy(secondField = Some(_f))
+	def setNestedOuterField(_f: ComplexMessage.Nested) = copy(nestedOuterField = Some(_f))
+	def setSimpleEnumField(_i: Int, _v: ComplexMessage.SimpleEnum.EnumVal) = copy(simpleEnumField = simpleEnumField.updated(_i, _v))
+	def addSimpleEnumField(_f: ComplexMessage.SimpleEnum.EnumVal) = copy(simpleEnumField = simpleEnumField :+ _f)
+	def addAllSimpleEnumField(_f: ComplexMessage.SimpleEnum.EnumVal*) = copy(simpleEnumField = simpleEnumField ++ _f)
+	def addAllSimpleEnumField(_f: TraversableOnce[ComplexMessage.SimpleEnum.EnumVal]) = copy(simpleEnumField = simpleEnumField ++ _f)
+	def setRepeatedStringField(_i: Int, _v: String) = copy(repeatedStringField = repeatedStringField.updated(_i, _v))
+	def addRepeatedStringField(_f: String) = copy(repeatedStringField = repeatedStringField :+ _f)
+	def addAllRepeatedStringField(_f: String*) = copy(repeatedStringField = repeatedStringField ++ _f)
+	def addAllRepeatedStringField(_f: TraversableOnce[String]) = copy(repeatedStringField = repeatedStringField ++ _f)
+	def setRepeatedBytesField(_i: Int, _v: com.google.protobuf.ByteString) = copy(repeatedBytesField = repeatedBytesField.updated(_i, _v))
+	def addRepeatedBytesField(_f: com.google.protobuf.ByteString) = copy(repeatedBytesField = repeatedBytesField :+ _f)
+	def addAllRepeatedBytesField(_f: com.google.protobuf.ByteString*) = copy(repeatedBytesField = repeatedBytesField ++ _f)
+	def addAllRepeatedBytesField(_f: TraversableOnce[com.google.protobuf.ByteString]) = copy(repeatedBytesField = repeatedBytesField ++ _f)
 
-	def clearSecondField = copy(`secondField` = None)
-	def clearNestedOuterField = copy(`nestedOuterField` = None)
-	def clearSimpleEnumField = copy(`simpleEnumField` = Vector.empty[ComplexMessage.SimpleEnum.EnumVal])
-	def clearRepeatedStringField = copy(`repeatedStringField` = Vector.empty[String])
-	def clearRepeatedBytesField = copy(`repeatedBytesField` = Vector.empty[com.google.protobuf.ByteString])
+	def clearSecondField = copy(secondField = None)
+	def clearNestedOuterField = copy(nestedOuterField = None)
+	def clearSimpleEnumField = copy(simpleEnumField = Vector.empty[ComplexMessage.SimpleEnum.EnumVal])
+	def clearRepeatedStringField = copy(repeatedStringField = Vector.empty[String])
+	def clearRepeatedBytesField = copy(repeatedBytesField = Vector.empty[com.google.protobuf.ByteString])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeBytes(1, `firstField`)
-		if (`secondField`.isDefined) output.writeString(2, `secondField`.get)
-		if (`nestedOuterField`.isDefined) output.writeMessage(3, `nestedOuterField`.get)
-		for (_v <- `simpleEnumField`) output.writeEnum(4, _v)
-		for (_v <- `repeatedStringField`) output.writeString(5, _v)
-		for (_v <- `repeatedBytesField`) output.writeBytes(6, _v)
+		output.writeBytes(1, firstField)
+		if (secondField.isDefined) output.writeString(2, secondField.get)
+		if (nestedOuterField.isDefined) output.writeMessage(3, nestedOuterField.get)
+		for (_v <- simpleEnumField) output.writeEnum(4, _v)
+		for (_v <- repeatedStringField) output.writeString(5, _v)
+		for (_v <- repeatedBytesField) output.writeBytes(6, _v)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeBytesSize(1, `firstField`)
-		if (`secondField`.isDefined) __size += computeStringSize(2, `secondField`.get)
-		if (`nestedOuterField`.isDefined) __size += computeMessageSize(3, `nestedOuterField`.get)
-		for (_v <- `simpleEnumField`) __size += computeEnumSize(4, _v)
-		for (_v <- `repeatedStringField`) __size += computeStringSize(5, _v)
-		for (_v <- `repeatedBytesField`) __size += computeBytesSize(6, _v)
+		__size += computeBytesSize(1, firstField)
+		if (secondField.isDefined) __size += computeStringSize(2, secondField.get)
+		if (nestedOuterField.isDefined) __size += computeMessageSize(3, nestedOuterField.get)
+		for (_v <- simpleEnumField) __size += computeEnumSize(4, _v)
+		for (_v <- repeatedStringField) __size += computeStringSize(5, _v)
+		for (_v <- repeatedBytesField) __size += computeBytesSize(6, _v)
 
 		__size
 	}
@@ -61,11 +61,11 @@ final case class ComplexMessage (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): ComplexMessage = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __firstField: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY
-		var __secondField: Option[String] = `secondField`
-		var __nestedOuterField: Option[ComplexMessage.Nested] = `nestedOuterField`
-		val __simpleEnumField: scala.collection.mutable.Buffer[ComplexMessage.SimpleEnum.EnumVal] = `simpleEnumField`.toBuffer
-		val __repeatedStringField: scala.collection.mutable.Buffer[String] = `repeatedStringField`.toBuffer
-		val __repeatedBytesField: scala.collection.mutable.Buffer[com.google.protobuf.ByteString] = `repeatedBytesField`.toBuffer
+		var __secondField: Option[String] = secondField
+		var __nestedOuterField: Option[ComplexMessage.Nested] = nestedOuterField
+		val __simpleEnumField: scala.collection.mutable.Buffer[ComplexMessage.SimpleEnum.EnumVal] = simpleEnumField.toBuffer
+		val __repeatedStringField: scala.collection.mutable.Buffer[String] = repeatedStringField.toBuffer
+		val __repeatedBytesField: scala.collection.mutable.Buffer[com.google.protobuf.ByteString] = repeatedBytesField.toBuffer
 
 		def __newMerged = ComplexMessage(
 			__firstField,
@@ -100,12 +100,12 @@ final case class ComplexMessage (
 
 	def mergeFrom(m: ComplexMessage) = {
 		ComplexMessage(
-			m.`firstField`,
-			m.`secondField`.orElse(`secondField`),
-			m.`nestedOuterField`.orElse(`nestedOuterField`),
-			`simpleEnumField` ++ m.`simpleEnumField`,
-			`repeatedStringField` ++ m.`repeatedStringField`,
-			`repeatedBytesField` ++ m.`repeatedBytesField`
+			m.firstField,
+			m.secondField.orElse(secondField),
+			m.nestedOuterField.orElse(nestedOuterField),
+			simpleEnumField ++ m.simpleEnumField,
+			repeatedStringField ++ m.repeatedStringField,
+			repeatedBytesField ++ m.repeatedBytesField
 		)
 	}
 
@@ -174,27 +174,27 @@ object ComplexMessage {
 	}
 
 	final case class Nested (
-		`nestedField`: String = "",
-		`nestedEnum`: Option[SimpleEnum.EnumVal] = None
+		nestedField: String = "",
+		nestedEnum: Option[SimpleEnum.EnumVal] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Nested]
 		with net.sandrogrzicic.scalabuff.Parser[Nested] {
 
-		def setNestedEnum(_f: SimpleEnum.EnumVal) = copy(`nestedEnum` = Some(_f))
+		def setNestedEnum(_f: SimpleEnum.EnumVal) = copy(nestedEnum = Some(_f))
 
-		def clearNestedEnum = copy(`nestedEnum` = None)
+		def clearNestedEnum = copy(nestedEnum = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			output.writeString(1, `nestedField`)
-			if (`nestedEnum`.isDefined) output.writeEnum(2, `nestedEnum`.get)
+			output.writeString(1, nestedField)
+			if (nestedEnum.isDefined) output.writeEnum(2, nestedEnum.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			__size += computeStringSize(1, `nestedField`)
-			if (`nestedEnum`.isDefined) __size += computeEnumSize(2, `nestedEnum`.get)
+			__size += computeStringSize(1, nestedField)
+			if (nestedEnum.isDefined) __size += computeEnumSize(2, nestedEnum.get)
 
 			__size
 		}
@@ -202,7 +202,7 @@ object ComplexMessage {
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Nested = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 			var __nestedField: String = ""
-			var __nestedEnum: Option[SimpleEnum.EnumVal] = `nestedEnum`
+			var __nestedEnum: Option[SimpleEnum.EnumVal] = nestedEnum
 
 			def __newMerged = Nested(
 				__nestedField,
@@ -219,8 +219,8 @@ object ComplexMessage {
 
 		def mergeFrom(m: Nested) = {
 			Nested(
-				m.`nestedField`,
-				m.`nestedEnum`.orElse(`nestedEnum`)
+				m.nestedField,
+				m.nestedEnum.orElse(nestedEnum)
 			)
 		}
 
@@ -266,8 +266,8 @@ object ComplexMessage {
 	}
 }
 final case class AnotherMessage (
-	`fieldNested`: ComplexMessage.Nested = ComplexMessage.Nested.defaultInstance,
-	`fieldEnum`: ComplexMessage.SimpleEnum.EnumVal = ComplexMessage.SimpleEnum._UNINITIALIZED
+	fieldNested: ComplexMessage.Nested = ComplexMessage.Nested.defaultInstance,
+	fieldEnum: ComplexMessage.SimpleEnum.EnumVal = ComplexMessage.SimpleEnum._UNINITIALIZED
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[AnotherMessage]
@@ -276,15 +276,15 @@ final case class AnotherMessage (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `fieldNested`)
-		output.writeEnum(2, `fieldEnum`)
+		output.writeMessage(1, fieldNested)
+		output.writeEnum(2, fieldEnum)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `fieldNested`)
-		__size += computeEnumSize(2, `fieldEnum`)
+		__size += computeMessageSize(1, fieldNested)
+		__size += computeEnumSize(2, fieldEnum)
 
 		__size
 	}
@@ -309,8 +309,8 @@ final case class AnotherMessage (
 
 	def mergeFrom(m: AnotherMessage) = {
 		AnotherMessage(
-			m.`fieldNested`,
-			m.`fieldEnum`
+			m.fieldNested,
+			m.fieldEnum
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/DataTypesTest.scala
+++ b/scalabuff-compiler/src/test/resources/generated/DataTypesTest.scala
@@ -4,121 +4,121 @@
 package resources.generated
 
 final case class DataTypes (
-	`varint1`: Int = 0,
-	`varint2`: Option[Long] = None,
-	`varint3`: Option[Int] = None,
-	`varint4`: Long = 0L,
-	`varint5`: Option[Int] = None,
-	`varint6`: Option[Long] = None,
-	`varint7`: Option[Boolean] = None,
-	`f64bit1`: Option[Long] = None,
-	`f64bit2`: Option[Long] = None,
-	`f64bit3`: Option[Double] = None,
-	`lengthDelim1`: Option[String] = None,
-	`lengthDelim2`: Option[com.google.protobuf.ByteString] = None,
-	`lengthDelim3`: Option[DataTypes.Varint8Enum.EnumVal] = None,
-	`lengthDelim4`: scala.collection.immutable.Seq[Int] = Vector.empty[Int],
-	`lengthDelim5`: scala.collection.immutable.Seq[Int] = Vector.empty[Int],
-	`f32bit1`: Option[Int] = None,
-	`f32bit2`: Option[Int] = None,
-	`f32bit3`: Option[Float] = None
+	varint1: Int = 0,
+	varint2: Option[Long] = None,
+	varint3: Option[Int] = None,
+	varint4: Long = 0L,
+	varint5: Option[Int] = None,
+	varint6: Option[Long] = None,
+	varint7: Option[Boolean] = None,
+	f64bit1: Option[Long] = None,
+	f64bit2: Option[Long] = None,
+	f64bit3: Option[Double] = None,
+	lengthDelim1: Option[String] = None,
+	lengthDelim2: Option[com.google.protobuf.ByteString] = None,
+	lengthDelim3: Option[DataTypes.Varint8Enum.EnumVal] = None,
+	lengthDelim4: scala.collection.immutable.Seq[Int] = Vector.empty[Int],
+	lengthDelim5: scala.collection.immutable.Seq[Int] = Vector.empty[Int],
+	f32bit1: Option[Int] = None,
+	f32bit2: Option[Int] = None,
+	f32bit3: Option[Float] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[DataTypes]
 	with net.sandrogrzicic.scalabuff.Parser[DataTypes] {
 
-	def setVarint2(_f: Long) = copy(`varint2` = Some(_f))
-	def setVarint3(_f: Int) = copy(`varint3` = Some(_f))
-	def setVarint5(_f: Int) = copy(`varint5` = Some(_f))
-	def setVarint6(_f: Long) = copy(`varint6` = Some(_f))
-	def setVarint7(_f: Boolean) = copy(`varint7` = Some(_f))
-	def setF64bit1(_f: Long) = copy(`f64bit1` = Some(_f))
-	def setF64bit2(_f: Long) = copy(`f64bit2` = Some(_f))
-	def setF64bit3(_f: Double) = copy(`f64bit3` = Some(_f))
-	def setLengthDelim1(_f: String) = copy(`lengthDelim1` = Some(_f))
-	def setLengthDelim2(_f: com.google.protobuf.ByteString) = copy(`lengthDelim2` = Some(_f))
-	def setLengthDelim3(_f: DataTypes.Varint8Enum.EnumVal) = copy(`lengthDelim3` = Some(_f))
-	def setLengthDelim4(_i: Int, _v: Int) = copy(`lengthDelim4` = `lengthDelim4`.updated(_i, _v))
-	def addLengthDelim4(_f: Int) = copy(`lengthDelim4` = `lengthDelim4` :+ _f)
-	def addAllLengthDelim4(_f: Int*) = copy(`lengthDelim4` = `lengthDelim4` ++ _f)
-	def addAllLengthDelim4(_f: TraversableOnce[Int]) = copy(`lengthDelim4` = `lengthDelim4` ++ _f)
-	def setLengthDelim5(_i: Int, _v: Int) = copy(`lengthDelim5` = `lengthDelim5`.updated(_i, _v))
-	def addLengthDelim5(_f: Int) = copy(`lengthDelim5` = `lengthDelim5` :+ _f)
-	def addAllLengthDelim5(_f: Int*) = copy(`lengthDelim5` = `lengthDelim5` ++ _f)
-	def addAllLengthDelim5(_f: TraversableOnce[Int]) = copy(`lengthDelim5` = `lengthDelim5` ++ _f)
-	def setF32bit1(_f: Int) = copy(`f32bit1` = Some(_f))
-	def setF32bit2(_f: Int) = copy(`f32bit2` = Some(_f))
-	def setF32bit3(_f: Float) = copy(`f32bit3` = Some(_f))
+	def setVarint2(_f: Long) = copy(varint2 = Some(_f))
+	def setVarint3(_f: Int) = copy(varint3 = Some(_f))
+	def setVarint5(_f: Int) = copy(varint5 = Some(_f))
+	def setVarint6(_f: Long) = copy(varint6 = Some(_f))
+	def setVarint7(_f: Boolean) = copy(varint7 = Some(_f))
+	def setF64bit1(_f: Long) = copy(f64bit1 = Some(_f))
+	def setF64bit2(_f: Long) = copy(f64bit2 = Some(_f))
+	def setF64bit3(_f: Double) = copy(f64bit3 = Some(_f))
+	def setLengthDelim1(_f: String) = copy(lengthDelim1 = Some(_f))
+	def setLengthDelim2(_f: com.google.protobuf.ByteString) = copy(lengthDelim2 = Some(_f))
+	def setLengthDelim3(_f: DataTypes.Varint8Enum.EnumVal) = copy(lengthDelim3 = Some(_f))
+	def setLengthDelim4(_i: Int, _v: Int) = copy(lengthDelim4 = lengthDelim4.updated(_i, _v))
+	def addLengthDelim4(_f: Int) = copy(lengthDelim4 = lengthDelim4 :+ _f)
+	def addAllLengthDelim4(_f: Int*) = copy(lengthDelim4 = lengthDelim4 ++ _f)
+	def addAllLengthDelim4(_f: TraversableOnce[Int]) = copy(lengthDelim4 = lengthDelim4 ++ _f)
+	def setLengthDelim5(_i: Int, _v: Int) = copy(lengthDelim5 = lengthDelim5.updated(_i, _v))
+	def addLengthDelim5(_f: Int) = copy(lengthDelim5 = lengthDelim5 :+ _f)
+	def addAllLengthDelim5(_f: Int*) = copy(lengthDelim5 = lengthDelim5 ++ _f)
+	def addAllLengthDelim5(_f: TraversableOnce[Int]) = copy(lengthDelim5 = lengthDelim5 ++ _f)
+	def setF32bit1(_f: Int) = copy(f32bit1 = Some(_f))
+	def setF32bit2(_f: Int) = copy(f32bit2 = Some(_f))
+	def setF32bit3(_f: Float) = copy(f32bit3 = Some(_f))
 
-	def clearVarint2 = copy(`varint2` = None)
-	def clearVarint3 = copy(`varint3` = None)
-	def clearVarint5 = copy(`varint5` = None)
-	def clearVarint6 = copy(`varint6` = None)
-	def clearVarint7 = copy(`varint7` = None)
-	def clearF64bit1 = copy(`f64bit1` = None)
-	def clearF64bit2 = copy(`f64bit2` = None)
-	def clearF64bit3 = copy(`f64bit3` = None)
-	def clearLengthDelim1 = copy(`lengthDelim1` = None)
-	def clearLengthDelim2 = copy(`lengthDelim2` = None)
-	def clearLengthDelim3 = copy(`lengthDelim3` = None)
-	def clearLengthDelim4 = copy(`lengthDelim4` = Vector.empty[Int])
-	def clearLengthDelim5 = copy(`lengthDelim5` = Vector.empty[Int])
-	def clearF32bit1 = copy(`f32bit1` = None)
-	def clearF32bit2 = copy(`f32bit2` = None)
-	def clearF32bit3 = copy(`f32bit3` = None)
+	def clearVarint2 = copy(varint2 = None)
+	def clearVarint3 = copy(varint3 = None)
+	def clearVarint5 = copy(varint5 = None)
+	def clearVarint6 = copy(varint6 = None)
+	def clearVarint7 = copy(varint7 = None)
+	def clearF64bit1 = copy(f64bit1 = None)
+	def clearF64bit2 = copy(f64bit2 = None)
+	def clearF64bit3 = copy(f64bit3 = None)
+	def clearLengthDelim1 = copy(lengthDelim1 = None)
+	def clearLengthDelim2 = copy(lengthDelim2 = None)
+	def clearLengthDelim3 = copy(lengthDelim3 = None)
+	def clearLengthDelim4 = copy(lengthDelim4 = Vector.empty[Int])
+	def clearLengthDelim5 = copy(lengthDelim5 = Vector.empty[Int])
+	def clearF32bit1 = copy(f32bit1 = None)
+	def clearF32bit2 = copy(f32bit2 = None)
+	def clearF32bit3 = copy(f32bit3 = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `varint1`)
-		if (`varint2`.isDefined) output.writeInt64(2, `varint2`.get)
-		if (`varint3`.isDefined) output.writeUInt32(3, `varint3`.get)
-		output.writeUInt64(4, `varint4`)
-		if (`varint5`.isDefined) output.writeSInt32(5, `varint5`.get)
-		if (`varint6`.isDefined) output.writeSInt64(6, `varint6`.get)
-		if (`varint7`.isDefined) output.writeBool(7, `varint7`.get)
-		if (`f64bit1`.isDefined) output.writeFixed64(100, `f64bit1`.get)
-		if (`f64bit2`.isDefined) output.writeSFixed64(101, `f64bit2`.get)
-		if (`f64bit3`.isDefined) output.writeDouble(102, `f64bit3`.get)
-		if (`lengthDelim1`.isDefined) output.writeString(200, `lengthDelim1`.get)
-		if (`lengthDelim2`.isDefined) output.writeBytes(201, `lengthDelim2`.get)
-		if (`lengthDelim3`.isDefined) output.writeEnum(202, `lengthDelim3`.get)
-		for (_v <- `lengthDelim4`) output.writeInt32(204, _v)
+		output.writeInt32(1, varint1)
+		if (varint2.isDefined) output.writeInt64(2, varint2.get)
+		if (varint3.isDefined) output.writeUInt32(3, varint3.get)
+		output.writeUInt64(4, varint4)
+		if (varint5.isDefined) output.writeSInt32(5, varint5.get)
+		if (varint6.isDefined) output.writeSInt64(6, varint6.get)
+		if (varint7.isDefined) output.writeBool(7, varint7.get)
+		if (f64bit1.isDefined) output.writeFixed64(100, f64bit1.get)
+		if (f64bit2.isDefined) output.writeSFixed64(101, f64bit2.get)
+		if (f64bit3.isDefined) output.writeDouble(102, f64bit3.get)
+		if (lengthDelim1.isDefined) output.writeString(200, lengthDelim1.get)
+		if (lengthDelim2.isDefined) output.writeBytes(201, lengthDelim2.get)
+		if (lengthDelim3.isDefined) output.writeEnum(202, lengthDelim3.get)
+		for (_v <- lengthDelim4) output.writeInt32(204, _v)
 		// write field length_delim5 packed 
-		if (!`lengthDelim5`.isEmpty) {
+		if (!lengthDelim5.isEmpty) {
 			import com.google.protobuf.CodedOutputStream._
-			val dataSize = `lengthDelim5`.map(computeInt32SizeNoTag(_)).sum 
+			val dataSize = lengthDelim5.map(computeInt32SizeNoTag(_)).sum 
 			output.writeRawVarint32(1626)
 			output.writeRawVarint32(dataSize)
-			for (_v <- `lengthDelim5`) output.writeInt32NoTag(_v)
+			for (_v <- lengthDelim5) output.writeInt32NoTag(_v)
 		}
-		if (`f32bit1`.isDefined) output.writeFixed32(500, `f32bit1`.get)
-		if (`f32bit2`.isDefined) output.writeSFixed32(501, `f32bit2`.get)
-		if (`f32bit3`.isDefined) output.writeFloat(502, `f32bit3`.get)
+		if (f32bit1.isDefined) output.writeFixed32(500, f32bit1.get)
+		if (f32bit2.isDefined) output.writeSFixed32(501, f32bit2.get)
+		if (f32bit3.isDefined) output.writeFloat(502, f32bit3.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `varint1`)
-		if (`varint2`.isDefined) __size += computeInt64Size(2, `varint2`.get)
-		if (`varint3`.isDefined) __size += computeUInt32Size(3, `varint3`.get)
-		__size += computeUInt64Size(4, `varint4`)
-		if (`varint5`.isDefined) __size += computeSInt32Size(5, `varint5`.get)
-		if (`varint6`.isDefined) __size += computeSInt64Size(6, `varint6`.get)
-		if (`varint7`.isDefined) __size += computeBoolSize(7, `varint7`.get)
-		if (`f64bit1`.isDefined) __size += computeFixed64Size(100, `f64bit1`.get)
-		if (`f64bit2`.isDefined) __size += computeSFixed64Size(101, `f64bit2`.get)
-		if (`f64bit3`.isDefined) __size += computeDoubleSize(102, `f64bit3`.get)
-		if (`lengthDelim1`.isDefined) __size += computeStringSize(200, `lengthDelim1`.get)
-		if (`lengthDelim2`.isDefined) __size += computeBytesSize(201, `lengthDelim2`.get)
-		if (`lengthDelim3`.isDefined) __size += computeEnumSize(202, `lengthDelim3`.get)
-		for (_v <- `lengthDelim4`) __size += computeInt32Size(204, _v)
-		if (!`lengthDelim5`.isEmpty) {
-			val dataSize = `lengthDelim5`.map(computeInt32SizeNoTag(_)).sum 
+		__size += computeInt32Size(1, varint1)
+		if (varint2.isDefined) __size += computeInt64Size(2, varint2.get)
+		if (varint3.isDefined) __size += computeUInt32Size(3, varint3.get)
+		__size += computeUInt64Size(4, varint4)
+		if (varint5.isDefined) __size += computeSInt32Size(5, varint5.get)
+		if (varint6.isDefined) __size += computeSInt64Size(6, varint6.get)
+		if (varint7.isDefined) __size += computeBoolSize(7, varint7.get)
+		if (f64bit1.isDefined) __size += computeFixed64Size(100, f64bit1.get)
+		if (f64bit2.isDefined) __size += computeSFixed64Size(101, f64bit2.get)
+		if (f64bit3.isDefined) __size += computeDoubleSize(102, f64bit3.get)
+		if (lengthDelim1.isDefined) __size += computeStringSize(200, lengthDelim1.get)
+		if (lengthDelim2.isDefined) __size += computeBytesSize(201, lengthDelim2.get)
+		if (lengthDelim3.isDefined) __size += computeEnumSize(202, lengthDelim3.get)
+		for (_v <- lengthDelim4) __size += computeInt32Size(204, _v)
+		if (!lengthDelim5.isEmpty) {
+			val dataSize = lengthDelim5.map(computeInt32SizeNoTag(_)).sum 
 			__size += 2 + computeInt32SizeNoTag(dataSize) + dataSize
 		}
-		if (`f32bit1`.isDefined) __size += computeFixed32Size(500, `f32bit1`.get)
-		if (`f32bit2`.isDefined) __size += computeSFixed32Size(501, `f32bit2`.get)
-		if (`f32bit3`.isDefined) __size += computeFloatSize(502, `f32bit3`.get)
+		if (f32bit1.isDefined) __size += computeFixed32Size(500, f32bit1.get)
+		if (f32bit2.isDefined) __size += computeSFixed32Size(501, f32bit2.get)
+		if (f32bit3.isDefined) __size += computeFloatSize(502, f32bit3.get)
 
 		__size
 	}
@@ -126,23 +126,23 @@ final case class DataTypes (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): DataTypes = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __varint1: Int = 0
-		var __varint2: Option[Long] = `varint2`
-		var __varint3: Option[Int] = `varint3`
+		var __varint2: Option[Long] = varint2
+		var __varint3: Option[Int] = varint3
 		var __varint4: Long = 0L
-		var __varint5: Option[Int] = `varint5`
-		var __varint6: Option[Long] = `varint6`
-		var __varint7: Option[Boolean] = `varint7`
-		var __f64bit1: Option[Long] = `f64bit1`
-		var __f64bit2: Option[Long] = `f64bit2`
-		var __f64bit3: Option[Double] = `f64bit3`
-		var __lengthDelim1: Option[String] = `lengthDelim1`
-		var __lengthDelim2: Option[com.google.protobuf.ByteString] = `lengthDelim2`
-		var __lengthDelim3: Option[DataTypes.Varint8Enum.EnumVal] = `lengthDelim3`
-		val __lengthDelim4: scala.collection.mutable.Buffer[Int] = `lengthDelim4`.toBuffer
-		val __lengthDelim5: scala.collection.mutable.Buffer[Int] = `lengthDelim5`.toBuffer
-		var __f32bit1: Option[Int] = `f32bit1`
-		var __f32bit2: Option[Int] = `f32bit2`
-		var __f32bit3: Option[Float] = `f32bit3`
+		var __varint5: Option[Int] = varint5
+		var __varint6: Option[Long] = varint6
+		var __varint7: Option[Boolean] = varint7
+		var __f64bit1: Option[Long] = f64bit1
+		var __f64bit2: Option[Long] = f64bit2
+		var __f64bit3: Option[Double] = f64bit3
+		var __lengthDelim1: Option[String] = lengthDelim1
+		var __lengthDelim2: Option[com.google.protobuf.ByteString] = lengthDelim2
+		var __lengthDelim3: Option[DataTypes.Varint8Enum.EnumVal] = lengthDelim3
+		val __lengthDelim4: scala.collection.mutable.Buffer[Int] = lengthDelim4.toBuffer
+		val __lengthDelim5: scala.collection.mutable.Buffer[Int] = lengthDelim5.toBuffer
+		var __f32bit1: Option[Int] = f32bit1
+		var __f32bit2: Option[Int] = f32bit2
+		var __f32bit3: Option[Float] = f32bit3
 
 		def __newMerged = DataTypes(
 			__varint1,
@@ -205,24 +205,24 @@ final case class DataTypes (
 
 	def mergeFrom(m: DataTypes) = {
 		DataTypes(
-			m.`varint1`,
-			m.`varint2`.orElse(`varint2`),
-			m.`varint3`.orElse(`varint3`),
-			m.`varint4`,
-			m.`varint5`.orElse(`varint5`),
-			m.`varint6`.orElse(`varint6`),
-			m.`varint7`.orElse(`varint7`),
-			m.`f64bit1`.orElse(`f64bit1`),
-			m.`f64bit2`.orElse(`f64bit2`),
-			m.`f64bit3`.orElse(`f64bit3`),
-			m.`lengthDelim1`.orElse(`lengthDelim1`),
-			m.`lengthDelim2`.orElse(`lengthDelim2`),
-			m.`lengthDelim3`.orElse(`lengthDelim3`),
-			`lengthDelim4` ++ m.`lengthDelim4`,
-			`lengthDelim5` ++ m.`lengthDelim5`,
-			m.`f32bit1`.orElse(`f32bit1`),
-			m.`f32bit2`.orElse(`f32bit2`),
-			m.`f32bit3`.orElse(`f32bit3`)
+			m.varint1,
+			m.varint2.orElse(varint2),
+			m.varint3.orElse(varint3),
+			m.varint4,
+			m.varint5.orElse(varint5),
+			m.varint6.orElse(varint6),
+			m.varint7.orElse(varint7),
+			m.f64bit1.orElse(f64bit1),
+			m.f64bit2.orElse(f64bit2),
+			m.f64bit3.orElse(f64bit3),
+			m.lengthDelim1.orElse(lengthDelim1),
+			m.lengthDelim2.orElse(lengthDelim2),
+			m.lengthDelim3.orElse(lengthDelim3),
+			lengthDelim4 ++ m.lengthDelim4,
+			lengthDelim5 ++ m.lengthDelim5,
+			m.f32bit1.orElse(f32bit1),
+			m.f32bit2.orElse(f32bit2),
+			m.f32bit3.orElse(f32bit3)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/DhComplex.scala
+++ b/scalabuff-compiler/src/test/resources/generated/DhComplex.scala
@@ -4,34 +4,34 @@
 package resources.generated
 
 final case class Response (
-	`response`: scala.collection.immutable.Seq[Response.VideoResult] = Vector.empty[Response.VideoResult]
+	response: scala.collection.immutable.Seq[Response.VideoResult] = Vector.empty[Response.VideoResult]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[Response]
 	with net.sandrogrzicic.scalabuff.Parser[Response] {
 
-	def setResponse(_i: Int, _v: Response.VideoResult) = copy(`response` = `response`.updated(_i, _v))
-	def addResponse(_f: Response.VideoResult) = copy(`response` = `response` :+ _f)
-	def addAllResponse(_f: Response.VideoResult*) = copy(`response` = `response` ++ _f)
-	def addAllResponse(_f: TraversableOnce[Response.VideoResult]) = copy(`response` = `response` ++ _f)
+	def setResponse(_i: Int, _v: Response.VideoResult) = copy(response = response.updated(_i, _v))
+	def addResponse(_f: Response.VideoResult) = copy(response = response :+ _f)
+	def addAllResponse(_f: Response.VideoResult*) = copy(response = response ++ _f)
+	def addAllResponse(_f: TraversableOnce[Response.VideoResult]) = copy(response = response ++ _f)
 
-	def clearResponse = copy(`response` = Vector.empty[Response.VideoResult])
+	def clearResponse = copy(response = Vector.empty[Response.VideoResult])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		for (_v <- `response`) output.writeMessage(1, _v)
+		for (_v <- response) output.writeMessage(1, _v)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		for (_v <- `response`) __size += computeMessageSize(1, _v)
+		for (_v <- response) __size += computeMessageSize(1, _v)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Response = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		val __response: scala.collection.mutable.Buffer[Response.VideoResult] = `response`.toBuffer
+		val __response: scala.collection.mutable.Buffer[Response.VideoResult] = response.toBuffer
 
 		def __newMerged = Response(
 			Vector(__response: _*)
@@ -46,7 +46,7 @@ final case class Response (
 
 	def mergeFrom(m: Response) = {
 		Response(
-			`response` ++ m.`response`
+			response ++ m.response
 		)
 	}
 
@@ -88,46 +88,46 @@ object Response {
 	def newBuilder(prototype: Response) = defaultInstance.mergeFrom(prototype)
 
 	final case class Rendition (
-		`profileKey`: Option[String] = None,
-		`data`: Option[String] = None,
-		`property`: scala.collection.immutable.Seq[Rendition.Property] = Vector.empty[Rendition.Property]
+		profileKey: Option[String] = None,
+		data: Option[String] = None,
+		property: scala.collection.immutable.Seq[Rendition.Property] = Vector.empty[Rendition.Property]
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Rendition]
 		with net.sandrogrzicic.scalabuff.Parser[Rendition] {
 
-		def setProfileKey(_f: String) = copy(`profileKey` = Some(_f))
-		def setData(_f: String) = copy(`data` = Some(_f))
-		def setProperty(_i: Int, _v: Rendition.Property) = copy(`property` = `property`.updated(_i, _v))
-		def addProperty(_f: Rendition.Property) = copy(`property` = `property` :+ _f)
-		def addAllProperty(_f: Rendition.Property*) = copy(`property` = `property` ++ _f)
-		def addAllProperty(_f: TraversableOnce[Rendition.Property]) = copy(`property` = `property` ++ _f)
+		def setProfileKey(_f: String) = copy(profileKey = Some(_f))
+		def setData(_f: String) = copy(data = Some(_f))
+		def setProperty(_i: Int, _v: Rendition.Property) = copy(property = property.updated(_i, _v))
+		def addProperty(_f: Rendition.Property) = copy(property = property :+ _f)
+		def addAllProperty(_f: Rendition.Property*) = copy(property = property ++ _f)
+		def addAllProperty(_f: TraversableOnce[Rendition.Property]) = copy(property = property ++ _f)
 
-		def clearProfileKey = copy(`profileKey` = None)
-		def clearData = copy(`data` = None)
-		def clearProperty = copy(`property` = Vector.empty[Rendition.Property])
+		def clearProfileKey = copy(profileKey = None)
+		def clearData = copy(data = None)
+		def clearProperty = copy(property = Vector.empty[Rendition.Property])
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`profileKey`.isDefined) output.writeString(1, `profileKey`.get)
-			if (`data`.isDefined) output.writeString(2, `data`.get)
-			for (_v <- `property`) output.writeMessage(3, _v)
+			if (profileKey.isDefined) output.writeString(1, profileKey.get)
+			if (data.isDefined) output.writeString(2, data.get)
+			for (_v <- property) output.writeMessage(3, _v)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`profileKey`.isDefined) __size += computeStringSize(1, `profileKey`.get)
-			if (`data`.isDefined) __size += computeStringSize(2, `data`.get)
-			for (_v <- `property`) __size += computeMessageSize(3, _v)
+			if (profileKey.isDefined) __size += computeStringSize(1, profileKey.get)
+			if (data.isDefined) __size += computeStringSize(2, data.get)
+			for (_v <- property) __size += computeMessageSize(3, _v)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Rendition = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __profileKey: Option[String] = `profileKey`
-			var __data: Option[String] = `data`
-			val __property: scala.collection.mutable.Buffer[Rendition.Property] = `property`.toBuffer
+			var __profileKey: Option[String] = profileKey
+			var __data: Option[String] = data
+			val __property: scala.collection.mutable.Buffer[Rendition.Property] = property.toBuffer
 
 			def __newMerged = Rendition(
 				__profileKey,
@@ -146,9 +146,9 @@ object Response {
 
 		def mergeFrom(m: Rendition) = {
 			Rendition(
-				m.`profileKey`.orElse(`profileKey`),
-				m.`data`.orElse(`data`),
-				`property` ++ m.`property`
+				m.profileKey.orElse(profileKey),
+				m.data.orElse(data),
+				property ++ m.property
 			)
 		}
 
@@ -194,8 +194,8 @@ object Response {
 		def newBuilder(prototype: Rendition) = defaultInstance.mergeFrom(prototype)
 
 		final case class Property (
-			`key`: Property.Key.EnumVal = Property.Key._UNINITIALIZED,
-			`value`: String = ""
+			key: Property.Key.EnumVal = Property.Key._UNINITIALIZED,
+			value: String = ""
 		) extends com.google.protobuf.GeneratedMessageLite
 			with com.google.protobuf.MessageLite.Builder
 			with net.sandrogrzicic.scalabuff.Message[Property]
@@ -204,15 +204,15 @@ object Response {
 
 
 			def writeTo(output: com.google.protobuf.CodedOutputStream) {
-				output.writeEnum(1, `key`)
-				output.writeString(2, `value`)
+				output.writeEnum(1, key)
+				output.writeString(2, value)
 			}
 
 			def getSerializedSize = {
 				import com.google.protobuf.CodedOutputStream._
 				var __size = 0
-				__size += computeEnumSize(1, `key`)
-				__size += computeStringSize(2, `value`)
+				__size += computeEnumSize(1, key)
+				__size += computeStringSize(2, value)
 
 				__size
 			}
@@ -237,8 +237,8 @@ object Response {
 
 			def mergeFrom(m: Property) = {
 				Property(
-					m.`key`,
-					m.`value`
+					m.key,
+					m.value
 				)
 			}
 
@@ -310,52 +310,52 @@ object Response {
 		}
 	}
 	final case class Video (
-		`identifier`: Option[String] = None,
-		`assetKey`: Option[String] = None,
-		`duration`: Option[Float] = None,
-		`renditions`: scala.collection.immutable.Seq[Rendition] = Vector.empty[Rendition]
+		identifier: Option[String] = None,
+		assetKey: Option[String] = None,
+		duration: Option[Float] = None,
+		renditions: scala.collection.immutable.Seq[Rendition] = Vector.empty[Rendition]
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Video]
 		with net.sandrogrzicic.scalabuff.Parser[Video] {
 
-		def setIdentifier(_f: String) = copy(`identifier` = Some(_f))
-		def setAssetKey(_f: String) = copy(`assetKey` = Some(_f))
-		def setDuration(_f: Float) = copy(`duration` = Some(_f))
-		def setRenditions(_i: Int, _v: Rendition) = copy(`renditions` = `renditions`.updated(_i, _v))
-		def addRenditions(_f: Rendition) = copy(`renditions` = `renditions` :+ _f)
-		def addAllRenditions(_f: Rendition*) = copy(`renditions` = `renditions` ++ _f)
-		def addAllRenditions(_f: TraversableOnce[Rendition]) = copy(`renditions` = `renditions` ++ _f)
+		def setIdentifier(_f: String) = copy(identifier = Some(_f))
+		def setAssetKey(_f: String) = copy(assetKey = Some(_f))
+		def setDuration(_f: Float) = copy(duration = Some(_f))
+		def setRenditions(_i: Int, _v: Rendition) = copy(renditions = renditions.updated(_i, _v))
+		def addRenditions(_f: Rendition) = copy(renditions = renditions :+ _f)
+		def addAllRenditions(_f: Rendition*) = copy(renditions = renditions ++ _f)
+		def addAllRenditions(_f: TraversableOnce[Rendition]) = copy(renditions = renditions ++ _f)
 
-		def clearIdentifier = copy(`identifier` = None)
-		def clearAssetKey = copy(`assetKey` = None)
-		def clearDuration = copy(`duration` = None)
-		def clearRenditions = copy(`renditions` = Vector.empty[Rendition])
+		def clearIdentifier = copy(identifier = None)
+		def clearAssetKey = copy(assetKey = None)
+		def clearDuration = copy(duration = None)
+		def clearRenditions = copy(renditions = Vector.empty[Rendition])
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`identifier`.isDefined) output.writeString(1, `identifier`.get)
-			if (`assetKey`.isDefined) output.writeString(2, `assetKey`.get)
-			if (`duration`.isDefined) output.writeFloat(3, `duration`.get)
-			for (_v <- `renditions`) output.writeMessage(4, _v)
+			if (identifier.isDefined) output.writeString(1, identifier.get)
+			if (assetKey.isDefined) output.writeString(2, assetKey.get)
+			if (duration.isDefined) output.writeFloat(3, duration.get)
+			for (_v <- renditions) output.writeMessage(4, _v)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`identifier`.isDefined) __size += computeStringSize(1, `identifier`.get)
-			if (`assetKey`.isDefined) __size += computeStringSize(2, `assetKey`.get)
-			if (`duration`.isDefined) __size += computeFloatSize(3, `duration`.get)
-			for (_v <- `renditions`) __size += computeMessageSize(4, _v)
+			if (identifier.isDefined) __size += computeStringSize(1, identifier.get)
+			if (assetKey.isDefined) __size += computeStringSize(2, assetKey.get)
+			if (duration.isDefined) __size += computeFloatSize(3, duration.get)
+			for (_v <- renditions) __size += computeMessageSize(4, _v)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Video = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __identifier: Option[String] = `identifier`
-			var __assetKey: Option[String] = `assetKey`
-			var __duration: Option[Float] = `duration`
-			val __renditions: scala.collection.mutable.Buffer[Rendition] = `renditions`.toBuffer
+			var __identifier: Option[String] = identifier
+			var __assetKey: Option[String] = assetKey
+			var __duration: Option[Float] = duration
+			val __renditions: scala.collection.mutable.Buffer[Rendition] = renditions.toBuffer
 
 			def __newMerged = Video(
 				__identifier,
@@ -376,10 +376,10 @@ object Response {
 
 		def mergeFrom(m: Video) = {
 			Video(
-				m.`identifier`.orElse(`identifier`),
-				m.`assetKey`.orElse(`assetKey`),
-				m.`duration`.orElse(`duration`),
-				`renditions` ++ m.`renditions`
+				m.identifier.orElse(identifier),
+				m.assetKey.orElse(assetKey),
+				m.duration.orElse(duration),
+				renditions ++ m.renditions
 			)
 		}
 
@@ -428,46 +428,46 @@ object Response {
 
 	}
 	final case class VideoFailure (
-		`assetKey`: Option[String] = None,
-		`reason`: scala.collection.immutable.Seq[String] = Vector.empty[String],
-		`cause`: Option[VideoFailure.Cause.EnumVal] = None
+		assetKey: Option[String] = None,
+		reason: scala.collection.immutable.Seq[String] = Vector.empty[String],
+		cause: Option[VideoFailure.Cause.EnumVal] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[VideoFailure]
 		with net.sandrogrzicic.scalabuff.Parser[VideoFailure] {
 
-		def setAssetKey(_f: String) = copy(`assetKey` = Some(_f))
-		def setReason(_i: Int, _v: String) = copy(`reason` = `reason`.updated(_i, _v))
-		def addReason(_f: String) = copy(`reason` = `reason` :+ _f)
-		def addAllReason(_f: String*) = copy(`reason` = `reason` ++ _f)
-		def addAllReason(_f: TraversableOnce[String]) = copy(`reason` = `reason` ++ _f)
-		def setCause(_f: VideoFailure.Cause.EnumVal) = copy(`cause` = Some(_f))
+		def setAssetKey(_f: String) = copy(assetKey = Some(_f))
+		def setReason(_i: Int, _v: String) = copy(reason = reason.updated(_i, _v))
+		def addReason(_f: String) = copy(reason = reason :+ _f)
+		def addAllReason(_f: String*) = copy(reason = reason ++ _f)
+		def addAllReason(_f: TraversableOnce[String]) = copy(reason = reason ++ _f)
+		def setCause(_f: VideoFailure.Cause.EnumVal) = copy(cause = Some(_f))
 
-		def clearAssetKey = copy(`assetKey` = None)
-		def clearReason = copy(`reason` = Vector.empty[String])
-		def clearCause = copy(`cause` = None)
+		def clearAssetKey = copy(assetKey = None)
+		def clearReason = copy(reason = Vector.empty[String])
+		def clearCause = copy(cause = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`assetKey`.isDefined) output.writeString(1, `assetKey`.get)
-			for (_v <- `reason`) output.writeString(2, _v)
-			if (`cause`.isDefined) output.writeEnum(3, `cause`.get)
+			if (assetKey.isDefined) output.writeString(1, assetKey.get)
+			for (_v <- reason) output.writeString(2, _v)
+			if (cause.isDefined) output.writeEnum(3, cause.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`assetKey`.isDefined) __size += computeStringSize(1, `assetKey`.get)
-			for (_v <- `reason`) __size += computeStringSize(2, _v)
-			if (`cause`.isDefined) __size += computeEnumSize(3, `cause`.get)
+			if (assetKey.isDefined) __size += computeStringSize(1, assetKey.get)
+			for (_v <- reason) __size += computeStringSize(2, _v)
+			if (cause.isDefined) __size += computeEnumSize(3, cause.get)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): VideoFailure = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __assetKey: Option[String] = `assetKey`
-			val __reason: scala.collection.mutable.Buffer[String] = `reason`.toBuffer
-			var __cause: Option[VideoFailure.Cause.EnumVal] = `cause`
+			var __assetKey: Option[String] = assetKey
+			val __reason: scala.collection.mutable.Buffer[String] = reason.toBuffer
+			var __cause: Option[VideoFailure.Cause.EnumVal] = cause
 
 			def __newMerged = VideoFailure(
 				__assetKey,
@@ -486,9 +486,9 @@ object Response {
 
 		def mergeFrom(m: VideoFailure) = {
 			VideoFailure(
-				m.`assetKey`.orElse(`assetKey`),
-				`reason` ++ m.`reason`,
-				m.`cause`.orElse(`cause`)
+				m.assetKey.orElse(assetKey),
+				reason ++ m.reason,
+				m.cause.orElse(cause)
 			)
 		}
 
@@ -564,37 +564,37 @@ object Response {
 
 	}
 	final case class VideoResult (
-		`success`: Option[Video] = None,
-		`failure`: Option[VideoFailure] = None
+		success: Option[Video] = None,
+		failure: Option[VideoFailure] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[VideoResult]
 		with net.sandrogrzicic.scalabuff.Parser[VideoResult] {
 
-		def setSuccess(_f: Video) = copy(`success` = Some(_f))
-		def setFailure(_f: VideoFailure) = copy(`failure` = Some(_f))
+		def setSuccess(_f: Video) = copy(success = Some(_f))
+		def setFailure(_f: VideoFailure) = copy(failure = Some(_f))
 
-		def clearSuccess = copy(`success` = None)
-		def clearFailure = copy(`failure` = None)
+		def clearSuccess = copy(success = None)
+		def clearFailure = copy(failure = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`success`.isDefined) output.writeMessage(1, `success`.get)
-			if (`failure`.isDefined) output.writeMessage(2, `failure`.get)
+			if (success.isDefined) output.writeMessage(1, success.get)
+			if (failure.isDefined) output.writeMessage(2, failure.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`success`.isDefined) __size += computeMessageSize(1, `success`.get)
-			if (`failure`.isDefined) __size += computeMessageSize(2, `failure`.get)
+			if (success.isDefined) __size += computeMessageSize(1, success.get)
+			if (failure.isDefined) __size += computeMessageSize(2, failure.get)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): VideoResult = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __success: Option[Video] = `success`
-			var __failure: Option[VideoFailure] = `failure`
+			var __success: Option[Video] = success
+			var __failure: Option[VideoFailure] = failure
 
 			def __newMerged = VideoResult(
 				__success,
@@ -617,8 +617,8 @@ object Response {
 
 		def mergeFrom(m: VideoResult) = {
 			VideoResult(
-				m.`success`.orElse(`success`),
-				m.`failure`.orElse(`failure`)
+				m.success.orElse(success),
+				m.failure.orElse(failure)
 			)
 		}
 

--- a/scalabuff-compiler/src/test/resources/generated/EnumTest.scala
+++ b/scalabuff-compiler/src/test/resources/generated/EnumTest.scala
@@ -23,37 +23,37 @@ object ComputerPeripherals extends net.sandrogrzicic.scalabuff.Enum {
 	}
 }
 final case class MyPeripherals (
-	`primaryPeripheral`: Option[ComputerPeripherals.EnumVal] = Some(ComputerPeripherals.KEYBOARD),
-	`secondaryPeripheral`: Option[ComputerPeripherals.EnumVal] = None
+	primaryPeripheral: Option[ComputerPeripherals.EnumVal] = Some(ComputerPeripherals.KEYBOARD),
+	secondaryPeripheral: Option[ComputerPeripherals.EnumVal] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[MyPeripherals]
 	with net.sandrogrzicic.scalabuff.Parser[MyPeripherals] {
 
-	def setPrimaryPeripheral(_f: ComputerPeripherals.EnumVal) = copy(`primaryPeripheral` = Some(_f))
-	def setSecondaryPeripheral(_f: ComputerPeripherals.EnumVal) = copy(`secondaryPeripheral` = Some(_f))
+	def setPrimaryPeripheral(_f: ComputerPeripherals.EnumVal) = copy(primaryPeripheral = Some(_f))
+	def setSecondaryPeripheral(_f: ComputerPeripherals.EnumVal) = copy(secondaryPeripheral = Some(_f))
 
-	def clearPrimaryPeripheral = copy(`primaryPeripheral` = None)
-	def clearSecondaryPeripheral = copy(`secondaryPeripheral` = None)
+	def clearPrimaryPeripheral = copy(primaryPeripheral = None)
+	def clearSecondaryPeripheral = copy(secondaryPeripheral = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		if (`primaryPeripheral`.isDefined) output.writeEnum(1, `primaryPeripheral`.get)
-		if (`secondaryPeripheral`.isDefined) output.writeEnum(2, `secondaryPeripheral`.get)
+		if (primaryPeripheral.isDefined) output.writeEnum(1, primaryPeripheral.get)
+		if (secondaryPeripheral.isDefined) output.writeEnum(2, secondaryPeripheral.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		if (`primaryPeripheral`.isDefined) __size += computeEnumSize(1, `primaryPeripheral`.get)
-		if (`secondaryPeripheral`.isDefined) __size += computeEnumSize(2, `secondaryPeripheral`.get)
+		if (primaryPeripheral.isDefined) __size += computeEnumSize(1, primaryPeripheral.get)
+		if (secondaryPeripheral.isDefined) __size += computeEnumSize(2, secondaryPeripheral.get)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): MyPeripherals = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		var __primaryPeripheral: Option[ComputerPeripherals.EnumVal] = `primaryPeripheral`
-		var __secondaryPeripheral: Option[ComputerPeripherals.EnumVal] = `secondaryPeripheral`
+		var __primaryPeripheral: Option[ComputerPeripherals.EnumVal] = primaryPeripheral
+		var __secondaryPeripheral: Option[ComputerPeripherals.EnumVal] = secondaryPeripheral
 
 		def __newMerged = MyPeripherals(
 			__primaryPeripheral,
@@ -70,8 +70,8 @@ final case class MyPeripherals (
 
 	def mergeFrom(m: MyPeripherals) = {
 		MyPeripherals(
-			m.`primaryPeripheral`.orElse(`primaryPeripheral`),
-			m.`secondaryPeripheral`.orElse(`secondaryPeripheral`)
+			m.primaryPeripheral.orElse(primaryPeripheral),
+			m.secondaryPeripheral.orElse(secondaryPeripheral)
 		)
 	}
 
@@ -116,35 +116,35 @@ object MyPeripherals {
 
 }
 final case class Outer (
-	`innerRequired`: Outer.Inner.EnumVal = Outer.Inner._UNINITIALIZED,
-	`innerOptional`: Option[Outer.Inner.EnumVal] = Some(Outer.Inner.FIRST),
-	`innerRepeated`: scala.collection.immutable.Seq[Outer.Inner.EnumVal] = Vector.empty[Outer.Inner.EnumVal]
+	innerRequired: Outer.Inner.EnumVal = Outer.Inner._UNINITIALIZED,
+	innerOptional: Option[Outer.Inner.EnumVal] = Some(Outer.Inner.FIRST),
+	innerRepeated: scala.collection.immutable.Seq[Outer.Inner.EnumVal] = Vector.empty[Outer.Inner.EnumVal]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[Outer]
 	with net.sandrogrzicic.scalabuff.Parser[Outer] {
 
-	def setInnerOptional(_f: Outer.Inner.EnumVal) = copy(`innerOptional` = Some(_f))
-	def setInnerRepeated(_i: Int, _v: Outer.Inner.EnumVal) = copy(`innerRepeated` = `innerRepeated`.updated(_i, _v))
-	def addInnerRepeated(_f: Outer.Inner.EnumVal) = copy(`innerRepeated` = `innerRepeated` :+ _f)
-	def addAllInnerRepeated(_f: Outer.Inner.EnumVal*) = copy(`innerRepeated` = `innerRepeated` ++ _f)
-	def addAllInnerRepeated(_f: TraversableOnce[Outer.Inner.EnumVal]) = copy(`innerRepeated` = `innerRepeated` ++ _f)
+	def setInnerOptional(_f: Outer.Inner.EnumVal) = copy(innerOptional = Some(_f))
+	def setInnerRepeated(_i: Int, _v: Outer.Inner.EnumVal) = copy(innerRepeated = innerRepeated.updated(_i, _v))
+	def addInnerRepeated(_f: Outer.Inner.EnumVal) = copy(innerRepeated = innerRepeated :+ _f)
+	def addAllInnerRepeated(_f: Outer.Inner.EnumVal*) = copy(innerRepeated = innerRepeated ++ _f)
+	def addAllInnerRepeated(_f: TraversableOnce[Outer.Inner.EnumVal]) = copy(innerRepeated = innerRepeated ++ _f)
 
-	def clearInnerOptional = copy(`innerOptional` = None)
-	def clearInnerRepeated = copy(`innerRepeated` = Vector.empty[Outer.Inner.EnumVal])
+	def clearInnerOptional = copy(innerOptional = None)
+	def clearInnerRepeated = copy(innerRepeated = Vector.empty[Outer.Inner.EnumVal])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeEnum(1, `innerRequired`)
-		if (`innerOptional`.isDefined) output.writeEnum(2, `innerOptional`.get)
-		for (_v <- `innerRepeated`) output.writeEnum(3, _v)
+		output.writeEnum(1, innerRequired)
+		if (innerOptional.isDefined) output.writeEnum(2, innerOptional.get)
+		for (_v <- innerRepeated) output.writeEnum(3, _v)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeEnumSize(1, `innerRequired`)
-		if (`innerOptional`.isDefined) __size += computeEnumSize(2, `innerOptional`.get)
-		for (_v <- `innerRepeated`) __size += computeEnumSize(3, _v)
+		__size += computeEnumSize(1, innerRequired)
+		if (innerOptional.isDefined) __size += computeEnumSize(2, innerOptional.get)
+		for (_v <- innerRepeated) __size += computeEnumSize(3, _v)
 
 		__size
 	}
@@ -152,8 +152,8 @@ final case class Outer (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Outer = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __innerRequired: Outer.Inner.EnumVal = Outer.Inner._UNINITIALIZED
-		var __innerOptional: Option[Outer.Inner.EnumVal] = `innerOptional`
-		val __innerRepeated: scala.collection.mutable.Buffer[Outer.Inner.EnumVal] = `innerRepeated`.toBuffer
+		var __innerOptional: Option[Outer.Inner.EnumVal] = innerOptional
+		val __innerRepeated: scala.collection.mutable.Buffer[Outer.Inner.EnumVal] = innerRepeated.toBuffer
 
 		def __newMerged = Outer(
 			__innerRequired,
@@ -179,9 +179,9 @@ final case class Outer (
 
 	def mergeFrom(m: Outer) = {
 		Outer(
-			m.`innerRequired`,
-			m.`innerOptional`.orElse(`innerOptional`),
-			`innerRepeated` ++ m.`innerRepeated`
+			m.innerRequired,
+			m.innerOptional.orElse(innerOptional),
+			innerRepeated ++ m.innerRepeated
 		)
 	}
 
@@ -248,35 +248,35 @@ object Outer {
 
 }
 final case class OuterDuplicate (
-	`innerRequired`: OuterDuplicate.Inner.EnumVal = OuterDuplicate.Inner._UNINITIALIZED,
-	`innerOptional`: Option[OuterDuplicate.Inner.EnumVal] = Some(OuterDuplicate.Inner.SECOND),
-	`innerRepeated`: scala.collection.immutable.Seq[OuterDuplicate.Inner.EnumVal] = Vector.empty[OuterDuplicate.Inner.EnumVal]
+	innerRequired: OuterDuplicate.Inner.EnumVal = OuterDuplicate.Inner._UNINITIALIZED,
+	innerOptional: Option[OuterDuplicate.Inner.EnumVal] = Some(OuterDuplicate.Inner.SECOND),
+	innerRepeated: scala.collection.immutable.Seq[OuterDuplicate.Inner.EnumVal] = Vector.empty[OuterDuplicate.Inner.EnumVal]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[OuterDuplicate]
 	with net.sandrogrzicic.scalabuff.Parser[OuterDuplicate] {
 
-	def setInnerOptional(_f: OuterDuplicate.Inner.EnumVal) = copy(`innerOptional` = Some(_f))
-	def setInnerRepeated(_i: Int, _v: OuterDuplicate.Inner.EnumVal) = copy(`innerRepeated` = `innerRepeated`.updated(_i, _v))
-	def addInnerRepeated(_f: OuterDuplicate.Inner.EnumVal) = copy(`innerRepeated` = `innerRepeated` :+ _f)
-	def addAllInnerRepeated(_f: OuterDuplicate.Inner.EnumVal*) = copy(`innerRepeated` = `innerRepeated` ++ _f)
-	def addAllInnerRepeated(_f: TraversableOnce[OuterDuplicate.Inner.EnumVal]) = copy(`innerRepeated` = `innerRepeated` ++ _f)
+	def setInnerOptional(_f: OuterDuplicate.Inner.EnumVal) = copy(innerOptional = Some(_f))
+	def setInnerRepeated(_i: Int, _v: OuterDuplicate.Inner.EnumVal) = copy(innerRepeated = innerRepeated.updated(_i, _v))
+	def addInnerRepeated(_f: OuterDuplicate.Inner.EnumVal) = copy(innerRepeated = innerRepeated :+ _f)
+	def addAllInnerRepeated(_f: OuterDuplicate.Inner.EnumVal*) = copy(innerRepeated = innerRepeated ++ _f)
+	def addAllInnerRepeated(_f: TraversableOnce[OuterDuplicate.Inner.EnumVal]) = copy(innerRepeated = innerRepeated ++ _f)
 
-	def clearInnerOptional = copy(`innerOptional` = None)
-	def clearInnerRepeated = copy(`innerRepeated` = Vector.empty[OuterDuplicate.Inner.EnumVal])
+	def clearInnerOptional = copy(innerOptional = None)
+	def clearInnerRepeated = copy(innerRepeated = Vector.empty[OuterDuplicate.Inner.EnumVal])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeEnum(1, `innerRequired`)
-		if (`innerOptional`.isDefined) output.writeEnum(2, `innerOptional`.get)
-		for (_v <- `innerRepeated`) output.writeEnum(3, _v)
+		output.writeEnum(1, innerRequired)
+		if (innerOptional.isDefined) output.writeEnum(2, innerOptional.get)
+		for (_v <- innerRepeated) output.writeEnum(3, _v)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeEnumSize(1, `innerRequired`)
-		if (`innerOptional`.isDefined) __size += computeEnumSize(2, `innerOptional`.get)
-		for (_v <- `innerRepeated`) __size += computeEnumSize(3, _v)
+		__size += computeEnumSize(1, innerRequired)
+		if (innerOptional.isDefined) __size += computeEnumSize(2, innerOptional.get)
+		for (_v <- innerRepeated) __size += computeEnumSize(3, _v)
 
 		__size
 	}
@@ -284,8 +284,8 @@ final case class OuterDuplicate (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): OuterDuplicate = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __innerRequired: OuterDuplicate.Inner.EnumVal = OuterDuplicate.Inner._UNINITIALIZED
-		var __innerOptional: Option[OuterDuplicate.Inner.EnumVal] = `innerOptional`
-		val __innerRepeated: scala.collection.mutable.Buffer[OuterDuplicate.Inner.EnumVal] = `innerRepeated`.toBuffer
+		var __innerOptional: Option[OuterDuplicate.Inner.EnumVal] = innerOptional
+		val __innerRepeated: scala.collection.mutable.Buffer[OuterDuplicate.Inner.EnumVal] = innerRepeated.toBuffer
 
 		def __newMerged = OuterDuplicate(
 			__innerRequired,
@@ -311,9 +311,9 @@ final case class OuterDuplicate (
 
 	def mergeFrom(m: OuterDuplicate) = {
 		OuterDuplicate(
-			m.`innerRequired`,
-			m.`innerOptional`.orElse(`innerOptional`),
-			`innerRepeated` ++ m.`innerRepeated`
+			m.innerRequired,
+			m.innerOptional.orElse(innerOptional),
+			innerRepeated ++ m.innerRepeated
 		)
 	}
 
@@ -380,7 +380,7 @@ object OuterDuplicate {
 
 }
 final case class OuterEnumContainer (
-	`innerMessage`: OuterEnumContainer.InnerEnumContainer = OuterEnumContainer.InnerEnumContainer.defaultInstance
+	innerMessage: OuterEnumContainer.InnerEnumContainer = OuterEnumContainer.InnerEnumContainer.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[OuterEnumContainer]
@@ -389,13 +389,13 @@ final case class OuterEnumContainer (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `innerMessage`)
+		output.writeMessage(1, innerMessage)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `innerMessage`)
+		__size += computeMessageSize(1, innerMessage)
 
 		__size
 	}
@@ -417,7 +417,7 @@ final case class OuterEnumContainer (
 
 	def mergeFrom(m: OuterEnumContainer) = {
 		OuterEnumContainer(
-			m.`innerMessage`
+			m.innerMessage
 		)
 	}
 
@@ -459,7 +459,7 @@ object OuterEnumContainer {
 	def newBuilder(prototype: OuterEnumContainer) = defaultInstance.mergeFrom(prototype)
 
 	final case class InnerEnumContainer (
-		`someEnum`: InnerEnumContainer.SomeEnum.EnumVal = InnerEnumContainer.SomeEnum._UNINITIALIZED
+		someEnum: InnerEnumContainer.SomeEnum.EnumVal = InnerEnumContainer.SomeEnum._UNINITIALIZED
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[InnerEnumContainer]
@@ -468,13 +468,13 @@ object OuterEnumContainer {
 
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			output.writeEnum(1, `someEnum`)
+			output.writeEnum(1, someEnum)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			__size += computeEnumSize(1, `someEnum`)
+			__size += computeEnumSize(1, someEnum)
 
 			__size
 		}
@@ -496,7 +496,7 @@ object OuterEnumContainer {
 
 		def mergeFrom(m: InnerEnumContainer) = {
 			InnerEnumContainer(
-				m.`someEnum`
+				m.someEnum
 			)
 		}
 

--- a/scalabuff-compiler/src/test/resources/generated/Extensions.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Extensions.scala
@@ -4,7 +4,7 @@
 package resources.generated
 
 final case class ExtensionsTest (
-	`foo`: Int = 0
+	foo: Int = 0
 ) extends com.google.protobuf.GeneratedMessageLite.ExtendableMessage[ExtensionsTest]
 	with net.sandrogrzicic.scalabuff.ExtendableMessage[ExtensionsTest]
 	with net.sandrogrzicic.scalabuff.Parser[ExtensionsTest] {
@@ -12,13 +12,13 @@ final case class ExtensionsTest (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `foo`)
+		output.writeInt32(1, foo)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `foo`)
+		__size += computeInt32Size(1, foo)
 
 		__size
 	}
@@ -40,7 +40,7 @@ final case class ExtensionsTest (
 
 	def mergeFrom(m: ExtensionsTest) = {
 		ExtensionsTest(
-			m.`foo`
+			m.foo
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
+++ b/scalabuff-compiler/src/test/resources/generated/ImportPackages.scala
@@ -6,7 +6,7 @@ package resources.generated
 //import "package_name.proto"
 
 final case class UsesImportPackage (
-	`packageTest`: resources.generated.nested.PackageTest = resources.generated.nested.PackageTest.defaultInstance
+	packageTest: nested.PackageTest = nested.PackageTest.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[UsesImportPackage]
@@ -15,27 +15,27 @@ final case class UsesImportPackage (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `packageTest`)
+		output.writeMessage(1, packageTest)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `packageTest`)
+		__size += computeMessageSize(1, packageTest)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): UsesImportPackage = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		var __packageTest: resources.generated.nested.PackageTest = resources.generated.nested.PackageTest.defaultInstance
+		var __packageTest: nested.PackageTest = nested.PackageTest.defaultInstance
 
 		def __newMerged = UsesImportPackage(
 			__packageTest
 		)
 		while (true) in.readTag match {
 			case 0 => return __newMerged
-			case 10 => __packageTest = readMessage[resources.generated.nested.PackageTest](in, __packageTest, _emptyRegistry)
+			case 10 => __packageTest = readMessage[nested.PackageTest](in, __packageTest, _emptyRegistry)
 			case default => if (!in.skipField(default)) return __newMerged
 		}
 		null
@@ -43,7 +43,7 @@ final case class UsesImportPackage (
 
 	def mergeFrom(m: UsesImportPackage) = {
 		UsesImportPackage(
-			m.`packageTest`
+			m.packageTest
 		)
 	}
 
@@ -56,7 +56,18 @@ final case class UsesImportPackage (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
-	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
+	def toJson(indent: Int = 0): String = {
+		val indent0 = "\n" + ("\t" * indent)
+		val (indent1, indent2) = (indent0 + "\t", indent0 + "\t\t")
+		val sb = StringBuilder.newBuilder
+		sb
+			.append("{")
+			sb.append(indent1).append("\"packageTest\": ").append(`packageTest`.toJson(indent + 1)).append(',')
+		if (sb.last.equals(',')) sb.length -= 1
+		sb.append(indent0).append("}")
+		sb.toString()
+	}
+
 }
 
 object UsesImportPackage {

--- a/scalabuff-compiler/src/test/resources/generated/ImportUseFullname.scala
+++ b/scalabuff-compiler/src/test/resources/generated/ImportUseFullname.scala
@@ -6,7 +6,7 @@ package resources.generated
 //import "package_name.proto"
 
 final case class UseFullImportedName (
-	`fullnameTest`: resources.generated.nested.PackageTest = resources.generated.nested.PackageTest.defaultInstance
+	fullnameTest: resources.generated.nested.PackageTest = resources.generated.nested.PackageTest.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[UseFullImportedName]
@@ -15,13 +15,13 @@ final case class UseFullImportedName (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `fullnameTest`)
+		output.writeMessage(1, fullnameTest)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `fullnameTest`)
+		__size += computeMessageSize(1, fullnameTest)
 
 		__size
 	}
@@ -43,7 +43,7 @@ final case class UseFullImportedName (
 
 	def mergeFrom(m: UseFullImportedName) = {
 		UseFullImportedName(
-			m.`fullnameTest`
+			m.fullnameTest
 		)
 	}
 
@@ -56,7 +56,18 @@ final case class UseFullImportedName (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
-	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
+	def toJson(indent: Int = 0): String = {
+		val indent0 = "\n" + ("\t" * indent)
+		val (indent1, indent2) = (indent0 + "\t", indent0 + "\t\t")
+		val sb = StringBuilder.newBuilder
+		sb
+			.append("{")
+			sb.append(indent1).append("\"fullnameTest\": ").append(`fullnameTest`.toJson(indent + 1)).append(',')
+		if (sb.last.equals(',')) sb.length -= 1
+		sb.append(indent0).append("}")
+		sb.toString()
+	}
+
 }
 
 object UseFullImportedName {

--- a/scalabuff-compiler/src/test/resources/generated/Imports.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Imports.scala
@@ -6,7 +6,7 @@ package resources.generated
 //import "simple.proto"
 
 final case class UsesImport (
-	`simpleTest`: SimpleTest = SimpleTest.defaultInstance
+	simpleTest: SimpleTest = SimpleTest.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[UsesImport]
@@ -15,13 +15,13 @@ final case class UsesImport (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `simpleTest`)
+		output.writeMessage(1, simpleTest)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `simpleTest`)
+		__size += computeMessageSize(1, simpleTest)
 
 		__size
 	}
@@ -43,7 +43,7 @@ final case class UsesImport (
 
 	def mergeFrom(m: UsesImport) = {
 		UsesImport(
-			m.`simpleTest`
+			m.simpleTest
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/Keywords.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Keywords.scala
@@ -4,7 +4,7 @@
 package resources.generated
 
 final case class KeywordsTest (
-	`size`: Long = 0L,
+	size: Long = 0L,
 	`case`: Int = 0,
 	`val`: Int = 0,
 	`var`: Int = 0,
@@ -21,7 +21,7 @@ final case class KeywordsTest (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt64(1, `size`)
+		output.writeInt64(1, size)
 		output.writeInt32(2, `case`)
 		output.writeInt32(3, `val`)
 		output.writeInt32(4, `var`)
@@ -35,7 +35,7 @@ final case class KeywordsTest (
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt64Size(1, `size`)
+		__size += computeInt64Size(1, size)
 		__size += computeInt32Size(2, `case`)
 		__size += computeInt32Size(3, `val`)
 		__size += computeInt32Size(4, `var`)
@@ -89,7 +89,7 @@ final case class KeywordsTest (
 
 	def mergeFrom(m: KeywordsTest) = {
 		KeywordsTest(
-			m.`size`,
+			m.size,
 			m.`case`,
 			m.`val`,
 			m.`var`,

--- a/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
+++ b/scalabuff-compiler/src/test/resources/generated/MultiTwo.scala
@@ -4,50 +4,50 @@
 package resources.generated
 
 final case class MultiMessageTwo (
-	`requiredField`: Int = 0,
-	`optionalField`: Option[Float] = None,
-	`repeatedField`: scala.collection.immutable.Seq[String] = Vector.empty[String],
+	requiredField: Int = 0,
+	optionalField: Option[Float] = None,
+	repeatedField: scala.collection.immutable.Seq[String] = Vector.empty[String],
 	`type`: Option[Int] = Some(100),
-	`int32Default`: Option[Int] = Some(100),
-	`stringDefault`: Option[String] = Some("somestring")
+	int32Default: Option[Int] = Some(100),
+	stringDefault: Option[String] = Some("somestring")
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[MultiMessageTwo]
 	with net.sandrogrzicic.scalabuff.Parser[MultiMessageTwo] {
 
-	def setOptionalField(_f: Float) = copy(`optionalField` = Some(_f))
-	def setRepeatedField(_i: Int, _v: String) = copy(`repeatedField` = `repeatedField`.updated(_i, _v))
-	def addRepeatedField(_f: String) = copy(`repeatedField` = `repeatedField` :+ _f)
-	def addAllRepeatedField(_f: String*) = copy(`repeatedField` = `repeatedField` ++ _f)
-	def addAllRepeatedField(_f: TraversableOnce[String]) = copy(`repeatedField` = `repeatedField` ++ _f)
+	def setOptionalField(_f: Float) = copy(optionalField = Some(_f))
+	def setRepeatedField(_i: Int, _v: String) = copy(repeatedField = repeatedField.updated(_i, _v))
+	def addRepeatedField(_f: String) = copy(repeatedField = repeatedField :+ _f)
+	def addAllRepeatedField(_f: String*) = copy(repeatedField = repeatedField ++ _f)
+	def addAllRepeatedField(_f: TraversableOnce[String]) = copy(repeatedField = repeatedField ++ _f)
 	def setType(_f: Int) = copy(`type` = Some(_f))
-	def setInt32Default(_f: Int) = copy(`int32Default` = Some(_f))
-	def setStringDefault(_f: String) = copy(`stringDefault` = Some(_f))
+	def setInt32Default(_f: Int) = copy(int32Default = Some(_f))
+	def setStringDefault(_f: String) = copy(stringDefault = Some(_f))
 
-	def clearOptionalField = copy(`optionalField` = None)
-	def clearRepeatedField = copy(`repeatedField` = Vector.empty[String])
+	def clearOptionalField = copy(optionalField = None)
+	def clearRepeatedField = copy(repeatedField = Vector.empty[String])
 	def clearType = copy(`type` = None)
-	def clearInt32Default = copy(`int32Default` = None)
-	def clearStringDefault = copy(`stringDefault` = None)
+	def clearInt32Default = copy(int32Default = None)
+	def clearStringDefault = copy(stringDefault = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `requiredField`)
-		if (`optionalField`.isDefined) output.writeFloat(2, `optionalField`.get)
-		for (_v <- `repeatedField`) output.writeString(3, _v)
+		output.writeInt32(1, requiredField)
+		if (optionalField.isDefined) output.writeFloat(2, optionalField.get)
+		for (_v <- repeatedField) output.writeString(3, _v)
 		if (`type`.isDefined) output.writeInt32(4, `type`.get)
-		if (`int32Default`.isDefined) output.writeInt32(5, `int32Default`.get)
-		if (`stringDefault`.isDefined) output.writeString(6, `stringDefault`.get)
+		if (int32Default.isDefined) output.writeInt32(5, int32Default.get)
+		if (stringDefault.isDefined) output.writeString(6, stringDefault.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `requiredField`)
-		if (`optionalField`.isDefined) __size += computeFloatSize(2, `optionalField`.get)
-		for (_v <- `repeatedField`) __size += computeStringSize(3, _v)
+		__size += computeInt32Size(1, requiredField)
+		if (optionalField.isDefined) __size += computeFloatSize(2, optionalField.get)
+		for (_v <- repeatedField) __size += computeStringSize(3, _v)
 		if (`type`.isDefined) __size += computeInt32Size(4, `type`.get)
-		if (`int32Default`.isDefined) __size += computeInt32Size(5, `int32Default`.get)
-		if (`stringDefault`.isDefined) __size += computeStringSize(6, `stringDefault`.get)
+		if (int32Default.isDefined) __size += computeInt32Size(5, int32Default.get)
+		if (stringDefault.isDefined) __size += computeStringSize(6, stringDefault.get)
 
 		__size
 	}
@@ -55,11 +55,11 @@ final case class MultiMessageTwo (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): MultiMessageTwo = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __requiredField: Int = 0
-		var __optionalField: Option[Float] = `optionalField`
-		val __repeatedField: scala.collection.mutable.Buffer[String] = `repeatedField`.toBuffer
+		var __optionalField: Option[Float] = optionalField
+		val __repeatedField: scala.collection.mutable.Buffer[String] = repeatedField.toBuffer
 		var __type: Option[Int] = `type`
-		var __int32Default: Option[Int] = `int32Default`
-		var __stringDefault: Option[String] = `stringDefault`
+		var __int32Default: Option[Int] = int32Default
+		var __stringDefault: Option[String] = stringDefault
 
 		def __newMerged = MultiMessageTwo(
 			__requiredField,
@@ -84,12 +84,12 @@ final case class MultiMessageTwo (
 
 	def mergeFrom(m: MultiMessageTwo) = {
 		MultiMessageTwo(
-			m.`requiredField`,
-			m.`optionalField`.orElse(`optionalField`),
-			`repeatedField` ++ m.`repeatedField`,
+			m.requiredField,
+			m.optionalField.orElse(optionalField),
+			repeatedField ++ m.repeatedField,
 			m.`type`.orElse(`type`),
-			m.`int32Default`.orElse(`int32Default`),
-			m.`stringDefault`.orElse(`stringDefault`)
+			m.int32Default.orElse(int32Default),
+			m.stringDefault.orElse(stringDefault)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/NestedMessages.scala
+++ b/scalabuff-compiler/src/test/resources/generated/NestedMessages.scala
@@ -4,7 +4,7 @@
 package resources.generated
 
 final case class TopLevel (
-	`idToplevel`: Int = 0
+	idToplevel: Int = 0
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[TopLevel]
@@ -13,13 +13,13 @@ final case class TopLevel (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeUInt32(1, `idToplevel`)
+		output.writeUInt32(1, idToplevel)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeUInt32Size(1, `idToplevel`)
+		__size += computeUInt32Size(1, idToplevel)
 
 		__size
 	}
@@ -41,7 +41,7 @@ final case class TopLevel (
 
 	def mergeFrom(m: TopLevel) = {
 		TopLevel(
-			m.`idToplevel`
+			m.idToplevel
 		)
 	}
 
@@ -83,7 +83,7 @@ object TopLevel {
 	def newBuilder(prototype: TopLevel) = defaultInstance.mergeFrom(prototype)
 
 	final case class Inner (
-		`idInner`: Int = 0
+		idInner: Int = 0
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Inner]
@@ -92,13 +92,13 @@ object TopLevel {
 
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			output.writeUInt32(1, `idInner`)
+			output.writeUInt32(1, idInner)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			__size += computeUInt32Size(1, `idInner`)
+			__size += computeUInt32Size(1, idInner)
 
 			__size
 		}
@@ -120,7 +120,7 @@ object TopLevel {
 
 		def mergeFrom(m: Inner) = {
 			Inner(
-				m.`idInner`
+				m.idInner
 			)
 		}
 
@@ -164,67 +164,67 @@ object TopLevel {
 	}
 }
 final case class Foobar (
-	`reqFoo`: Foobar.Foo = Foobar.Foo.defaultInstance,
-	`optFoo`: Option[Foobar.Foo] = None,
-	`optBar`: Option[Foobar.Bar] = None,
-	`repFoo`: scala.collection.immutable.Seq[Foobar.Foo] = Vector.empty[Foobar.Foo],
-	`repBar`: scala.collection.immutable.Seq[Foobar.Bar] = Vector.empty[Foobar.Bar],
-	`repFooBar`: scala.collection.immutable.Seq[Foobar.FooBar] = Vector.empty[Foobar.FooBar],
-	`topLevelReq`: TopLevel = TopLevel.defaultInstance,
-	`topLevelOpt`: Option[TopLevel] = None,
-	`topLevelInnerReq`: TopLevel.Inner = TopLevel.Inner.defaultInstance
+	reqFoo: Foobar.Foo = Foobar.Foo.defaultInstance,
+	optFoo: Option[Foobar.Foo] = None,
+	optBar: Option[Foobar.Bar] = None,
+	repFoo: scala.collection.immutable.Seq[Foobar.Foo] = Vector.empty[Foobar.Foo],
+	repBar: scala.collection.immutable.Seq[Foobar.Bar] = Vector.empty[Foobar.Bar],
+	repFooBar: scala.collection.immutable.Seq[Foobar.FooBar] = Vector.empty[Foobar.FooBar],
+	topLevelReq: TopLevel = TopLevel.defaultInstance,
+	topLevelOpt: Option[TopLevel] = None,
+	topLevelInnerReq: TopLevel.Inner = TopLevel.Inner.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[Foobar]
 	with net.sandrogrzicic.scalabuff.Parser[Foobar] {
 
-	def setOptFoo(_f: Foobar.Foo) = copy(`optFoo` = Some(_f))
-	def setOptBar(_f: Foobar.Bar) = copy(`optBar` = Some(_f))
-	def setRepFoo(_i: Int, _v: Foobar.Foo) = copy(`repFoo` = `repFoo`.updated(_i, _v))
-	def addRepFoo(_f: Foobar.Foo) = copy(`repFoo` = `repFoo` :+ _f)
-	def addAllRepFoo(_f: Foobar.Foo*) = copy(`repFoo` = `repFoo` ++ _f)
-	def addAllRepFoo(_f: TraversableOnce[Foobar.Foo]) = copy(`repFoo` = `repFoo` ++ _f)
-	def setRepBar(_i: Int, _v: Foobar.Bar) = copy(`repBar` = `repBar`.updated(_i, _v))
-	def addRepBar(_f: Foobar.Bar) = copy(`repBar` = `repBar` :+ _f)
-	def addAllRepBar(_f: Foobar.Bar*) = copy(`repBar` = `repBar` ++ _f)
-	def addAllRepBar(_f: TraversableOnce[Foobar.Bar]) = copy(`repBar` = `repBar` ++ _f)
-	def setRepFooBar(_i: Int, _v: Foobar.FooBar) = copy(`repFooBar` = `repFooBar`.updated(_i, _v))
-	def addRepFooBar(_f: Foobar.FooBar) = copy(`repFooBar` = `repFooBar` :+ _f)
-	def addAllRepFooBar(_f: Foobar.FooBar*) = copy(`repFooBar` = `repFooBar` ++ _f)
-	def addAllRepFooBar(_f: TraversableOnce[Foobar.FooBar]) = copy(`repFooBar` = `repFooBar` ++ _f)
-	def setTopLevelOpt(_f: TopLevel) = copy(`topLevelOpt` = Some(_f))
+	def setOptFoo(_f: Foobar.Foo) = copy(optFoo = Some(_f))
+	def setOptBar(_f: Foobar.Bar) = copy(optBar = Some(_f))
+	def setRepFoo(_i: Int, _v: Foobar.Foo) = copy(repFoo = repFoo.updated(_i, _v))
+	def addRepFoo(_f: Foobar.Foo) = copy(repFoo = repFoo :+ _f)
+	def addAllRepFoo(_f: Foobar.Foo*) = copy(repFoo = repFoo ++ _f)
+	def addAllRepFoo(_f: TraversableOnce[Foobar.Foo]) = copy(repFoo = repFoo ++ _f)
+	def setRepBar(_i: Int, _v: Foobar.Bar) = copy(repBar = repBar.updated(_i, _v))
+	def addRepBar(_f: Foobar.Bar) = copy(repBar = repBar :+ _f)
+	def addAllRepBar(_f: Foobar.Bar*) = copy(repBar = repBar ++ _f)
+	def addAllRepBar(_f: TraversableOnce[Foobar.Bar]) = copy(repBar = repBar ++ _f)
+	def setRepFooBar(_i: Int, _v: Foobar.FooBar) = copy(repFooBar = repFooBar.updated(_i, _v))
+	def addRepFooBar(_f: Foobar.FooBar) = copy(repFooBar = repFooBar :+ _f)
+	def addAllRepFooBar(_f: Foobar.FooBar*) = copy(repFooBar = repFooBar ++ _f)
+	def addAllRepFooBar(_f: TraversableOnce[Foobar.FooBar]) = copy(repFooBar = repFooBar ++ _f)
+	def setTopLevelOpt(_f: TopLevel) = copy(topLevelOpt = Some(_f))
 
-	def clearOptFoo = copy(`optFoo` = None)
-	def clearOptBar = copy(`optBar` = None)
-	def clearRepFoo = copy(`repFoo` = Vector.empty[Foobar.Foo])
-	def clearRepBar = copy(`repBar` = Vector.empty[Foobar.Bar])
-	def clearRepFooBar = copy(`repFooBar` = Vector.empty[Foobar.FooBar])
-	def clearTopLevelOpt = copy(`topLevelOpt` = None)
+	def clearOptFoo = copy(optFoo = None)
+	def clearOptBar = copy(optBar = None)
+	def clearRepFoo = copy(repFoo = Vector.empty[Foobar.Foo])
+	def clearRepBar = copy(repBar = Vector.empty[Foobar.Bar])
+	def clearRepFooBar = copy(repFooBar = Vector.empty[Foobar.FooBar])
+	def clearTopLevelOpt = copy(topLevelOpt = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `reqFoo`)
-		if (`optFoo`.isDefined) output.writeMessage(2, `optFoo`.get)
-		if (`optBar`.isDefined) output.writeMessage(3, `optBar`.get)
-		for (_v <- `repFoo`) output.writeMessage(4, _v)
-		for (_v <- `repBar`) output.writeMessage(5, _v)
-		for (_v <- `repFooBar`) output.writeMessage(6, _v)
-		output.writeMessage(7, `topLevelReq`)
-		if (`topLevelOpt`.isDefined) output.writeMessage(8, `topLevelOpt`.get)
-		output.writeMessage(9, `topLevelInnerReq`)
+		output.writeMessage(1, reqFoo)
+		if (optFoo.isDefined) output.writeMessage(2, optFoo.get)
+		if (optBar.isDefined) output.writeMessage(3, optBar.get)
+		for (_v <- repFoo) output.writeMessage(4, _v)
+		for (_v <- repBar) output.writeMessage(5, _v)
+		for (_v <- repFooBar) output.writeMessage(6, _v)
+		output.writeMessage(7, topLevelReq)
+		if (topLevelOpt.isDefined) output.writeMessage(8, topLevelOpt.get)
+		output.writeMessage(9, topLevelInnerReq)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `reqFoo`)
-		if (`optFoo`.isDefined) __size += computeMessageSize(2, `optFoo`.get)
-		if (`optBar`.isDefined) __size += computeMessageSize(3, `optBar`.get)
-		for (_v <- `repFoo`) __size += computeMessageSize(4, _v)
-		for (_v <- `repBar`) __size += computeMessageSize(5, _v)
-		for (_v <- `repFooBar`) __size += computeMessageSize(6, _v)
-		__size += computeMessageSize(7, `topLevelReq`)
-		if (`topLevelOpt`.isDefined) __size += computeMessageSize(8, `topLevelOpt`.get)
-		__size += computeMessageSize(9, `topLevelInnerReq`)
+		__size += computeMessageSize(1, reqFoo)
+		if (optFoo.isDefined) __size += computeMessageSize(2, optFoo.get)
+		if (optBar.isDefined) __size += computeMessageSize(3, optBar.get)
+		for (_v <- repFoo) __size += computeMessageSize(4, _v)
+		for (_v <- repBar) __size += computeMessageSize(5, _v)
+		for (_v <- repFooBar) __size += computeMessageSize(6, _v)
+		__size += computeMessageSize(7, topLevelReq)
+		if (topLevelOpt.isDefined) __size += computeMessageSize(8, topLevelOpt.get)
+		__size += computeMessageSize(9, topLevelInnerReq)
 
 		__size
 	}
@@ -232,13 +232,13 @@ final case class Foobar (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Foobar = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __reqFoo: Foobar.Foo = Foobar.Foo.defaultInstance
-		var __optFoo: Option[Foobar.Foo] = `optFoo`
-		var __optBar: Option[Foobar.Bar] = `optBar`
-		val __repFoo: scala.collection.mutable.Buffer[Foobar.Foo] = `repFoo`.toBuffer
-		val __repBar: scala.collection.mutable.Buffer[Foobar.Bar] = `repBar`.toBuffer
-		val __repFooBar: scala.collection.mutable.Buffer[Foobar.FooBar] = `repFooBar`.toBuffer
+		var __optFoo: Option[Foobar.Foo] = optFoo
+		var __optBar: Option[Foobar.Bar] = optBar
+		val __repFoo: scala.collection.mutable.Buffer[Foobar.Foo] = repFoo.toBuffer
+		val __repBar: scala.collection.mutable.Buffer[Foobar.Bar] = repBar.toBuffer
+		val __repFooBar: scala.collection.mutable.Buffer[Foobar.FooBar] = repFooBar.toBuffer
 		var __topLevelReq: TopLevel = TopLevel.defaultInstance
-		var __topLevelOpt: Option[TopLevel] = `topLevelOpt`
+		var __topLevelOpt: Option[TopLevel] = topLevelOpt
 		var __topLevelInnerReq: TopLevel.Inner = TopLevel.Inner.defaultInstance
 
 		def __newMerged = Foobar(
@@ -279,15 +279,15 @@ final case class Foobar (
 
 	def mergeFrom(m: Foobar) = {
 		Foobar(
-			m.`reqFoo`,
-			m.`optFoo`.orElse(`optFoo`),
-			m.`optBar`.orElse(`optBar`),
-			`repFoo` ++ m.`repFoo`,
-			`repBar` ++ m.`repBar`,
-			`repFooBar` ++ m.`repFooBar`,
-			m.`topLevelReq`,
-			m.`topLevelOpt`.orElse(`topLevelOpt`),
-			m.`topLevelInnerReq`
+			m.reqFoo,
+			m.optFoo.orElse(optFoo),
+			m.optBar.orElse(optBar),
+			repFoo ++ m.repFoo,
+			repBar ++ m.repBar,
+			repFooBar ++ m.repFooBar,
+			m.topLevelReq,
+			m.topLevelOpt.orElse(topLevelOpt),
+			m.topLevelInnerReq
 		)
 	}
 
@@ -345,31 +345,31 @@ object Foobar {
 	def newBuilder(prototype: Foobar) = defaultInstance.mergeFrom(prototype)
 
 	final case class Foo (
-		`id`: Option[Long] = None
+		id: Option[Long] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Foo]
 		with net.sandrogrzicic.scalabuff.Parser[Foo] {
 
-		def setId(_f: Long) = copy(`id` = Some(_f))
+		def setId(_f: Long) = copy(id = Some(_f))
 
-		def clearId = copy(`id` = None)
+		def clearId = copy(id = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`id`.isDefined) output.writeUInt64(1, `id`.get)
+			if (id.isDefined) output.writeUInt64(1, id.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`id`.isDefined) __size += computeUInt64Size(1, `id`.get)
+			if (id.isDefined) __size += computeUInt64Size(1, id.get)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Foo = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __id: Option[Long] = `id`
+			var __id: Option[Long] = id
 
 			def __newMerged = Foo(
 				__id
@@ -384,7 +384,7 @@ object Foobar {
 
 		def mergeFrom(m: Foo) = {
 			Foo(
-				m.`id`.orElse(`id`)
+				m.id.orElse(id)
 			)
 		}
 
@@ -427,31 +427,31 @@ object Foobar {
 
 	}
 	final case class Bar (
-		`id`: Option[Long] = None
+		id: Option[Long] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[Bar]
 		with net.sandrogrzicic.scalabuff.Parser[Bar] {
 
-		def setId(_f: Long) = copy(`id` = Some(_f))
+		def setId(_f: Long) = copy(id = Some(_f))
 
-		def clearId = copy(`id` = None)
+		def clearId = copy(id = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`id`.isDefined) output.writeUInt64(1, `id`.get)
+			if (id.isDefined) output.writeUInt64(1, id.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`id`.isDefined) __size += computeUInt64Size(1, `id`.get)
+			if (id.isDefined) __size += computeUInt64Size(1, id.get)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): Bar = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __id: Option[Long] = `id`
+			var __id: Option[Long] = id
 
 			def __newMerged = Bar(
 				__id
@@ -466,7 +466,7 @@ object Foobar {
 
 		def mergeFrom(m: Bar) = {
 			Bar(
-				m.`id`.orElse(`id`)
+				m.id.orElse(id)
 			)
 		}
 
@@ -509,31 +509,31 @@ object Foobar {
 
 	}
 	final case class FooBar (
-		`id`: Option[Long] = None
+		id: Option[Long] = None
 	) extends com.google.protobuf.GeneratedMessageLite
 		with com.google.protobuf.MessageLite.Builder
 		with net.sandrogrzicic.scalabuff.Message[FooBar]
 		with net.sandrogrzicic.scalabuff.Parser[FooBar] {
 
-		def setId(_f: Long) = copy(`id` = Some(_f))
+		def setId(_f: Long) = copy(id = Some(_f))
 
-		def clearId = copy(`id` = None)
+		def clearId = copy(id = None)
 
 		def writeTo(output: com.google.protobuf.CodedOutputStream) {
-			if (`id`.isDefined) output.writeUInt64(1, `id`.get)
+			if (id.isDefined) output.writeUInt64(1, id.get)
 		}
 
 		def getSerializedSize = {
 			import com.google.protobuf.CodedOutputStream._
 			var __size = 0
-			if (`id`.isDefined) __size += computeUInt64Size(1, `id`.get)
+			if (id.isDefined) __size += computeUInt64Size(1, id.get)
 
 			__size
 		}
 
 		def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): FooBar = {
 			import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-			var __id: Option[Long] = `id`
+			var __id: Option[Long] = id
 
 			def __newMerged = FooBar(
 				__id
@@ -548,7 +548,7 @@ object Foobar {
 
 		def mergeFrom(m: FooBar) = {
 			FooBar(
-				m.`id`.orElse(`id`)
+				m.id.orElse(id)
 			)
 		}
 

--- a/scalabuff-compiler/src/test/resources/generated/Numbers.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Numbers.scala
@@ -4,37 +4,37 @@
 package resources.generated
 
 final case class NumbersTest1 (
-	`someHexNumber`: Option[Int] = Some(430689775),
-	`someOctNumber`: Option[Int] = Some(342391)
+	someHexNumber: Option[Int] = Some(430689775),
+	someOctNumber: Option[Int] = Some(342391)
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[NumbersTest1]
 	with net.sandrogrzicic.scalabuff.Parser[NumbersTest1] {
 
-	def setSomeHexNumber(_f: Int) = copy(`someHexNumber` = Some(_f))
-	def setSomeOctNumber(_f: Int) = copy(`someOctNumber` = Some(_f))
+	def setSomeHexNumber(_f: Int) = copy(someHexNumber = Some(_f))
+	def setSomeOctNumber(_f: Int) = copy(someOctNumber = Some(_f))
 
-	def clearSomeHexNumber = copy(`someHexNumber` = None)
-	def clearSomeOctNumber = copy(`someOctNumber` = None)
+	def clearSomeHexNumber = copy(someHexNumber = None)
+	def clearSomeOctNumber = copy(someOctNumber = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		if (`someHexNumber`.isDefined) output.writeInt32(1, `someHexNumber`.get)
-		if (`someOctNumber`.isDefined) output.writeInt32(2, `someOctNumber`.get)
+		if (someHexNumber.isDefined) output.writeInt32(1, someHexNumber.get)
+		if (someOctNumber.isDefined) output.writeInt32(2, someOctNumber.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		if (`someHexNumber`.isDefined) __size += computeInt32Size(1, `someHexNumber`.get)
-		if (`someOctNumber`.isDefined) __size += computeInt32Size(2, `someOctNumber`.get)
+		if (someHexNumber.isDefined) __size += computeInt32Size(1, someHexNumber.get)
+		if (someOctNumber.isDefined) __size += computeInt32Size(2, someOctNumber.get)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): NumbersTest1 = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		var __someHexNumber: Option[Int] = `someHexNumber`
-		var __someOctNumber: Option[Int] = `someOctNumber`
+		var __someHexNumber: Option[Int] = someHexNumber
+		var __someOctNumber: Option[Int] = someOctNumber
 
 		def __newMerged = NumbersTest1(
 			__someHexNumber,
@@ -51,8 +51,8 @@ final case class NumbersTest1 (
 
 	def mergeFrom(m: NumbersTest1) = {
 		NumbersTest1(
-			m.`someHexNumber`.orElse(`someHexNumber`),
-			m.`someOctNumber`.orElse(`someOctNumber`)
+			m.someHexNumber.orElse(someHexNumber),
+			m.someOctNumber.orElse(someOctNumber)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/Packed.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Packed.scala
@@ -4,43 +4,43 @@
 package resources.generated
 
 final case class PackedTest (
-	`requiredField`: Int = 0,
-	`optionalField`: Option[Float] = None,
-	`repeatedPackedField`: scala.collection.immutable.Seq[Int] = Vector.empty[Int]
+	requiredField: Int = 0,
+	optionalField: Option[Float] = None,
+	repeatedPackedField: scala.collection.immutable.Seq[Int] = Vector.empty[Int]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[PackedTest]
 	with net.sandrogrzicic.scalabuff.Parser[PackedTest] {
 
-	def setOptionalField(_f: Float) = copy(`optionalField` = Some(_f))
-	def setRepeatedPackedField(_i: Int, _v: Int) = copy(`repeatedPackedField` = `repeatedPackedField`.updated(_i, _v))
-	def addRepeatedPackedField(_f: Int) = copy(`repeatedPackedField` = `repeatedPackedField` :+ _f)
-	def addAllRepeatedPackedField(_f: Int*) = copy(`repeatedPackedField` = `repeatedPackedField` ++ _f)
-	def addAllRepeatedPackedField(_f: TraversableOnce[Int]) = copy(`repeatedPackedField` = `repeatedPackedField` ++ _f)
+	def setOptionalField(_f: Float) = copy(optionalField = Some(_f))
+	def setRepeatedPackedField(_i: Int, _v: Int) = copy(repeatedPackedField = repeatedPackedField.updated(_i, _v))
+	def addRepeatedPackedField(_f: Int) = copy(repeatedPackedField = repeatedPackedField :+ _f)
+	def addAllRepeatedPackedField(_f: Int*) = copy(repeatedPackedField = repeatedPackedField ++ _f)
+	def addAllRepeatedPackedField(_f: TraversableOnce[Int]) = copy(repeatedPackedField = repeatedPackedField ++ _f)
 
-	def clearOptionalField = copy(`optionalField` = None)
-	def clearRepeatedPackedField = copy(`repeatedPackedField` = Vector.empty[Int])
+	def clearOptionalField = copy(optionalField = None)
+	def clearRepeatedPackedField = copy(repeatedPackedField = Vector.empty[Int])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `requiredField`)
-		if (`optionalField`.isDefined) output.writeFloat(2, `optionalField`.get)
+		output.writeInt32(1, requiredField)
+		if (optionalField.isDefined) output.writeFloat(2, optionalField.get)
 		// write field repeated_packed_field packed 
-		if (!`repeatedPackedField`.isEmpty) {
+		if (!repeatedPackedField.isEmpty) {
 			import com.google.protobuf.CodedOutputStream._
-			val dataSize = `repeatedPackedField`.map(computeInt32SizeNoTag(_)).sum 
+			val dataSize = repeatedPackedField.map(computeInt32SizeNoTag(_)).sum 
 			output.writeRawVarint32(26)
 			output.writeRawVarint32(dataSize)
-			for (_v <- `repeatedPackedField`) output.writeInt32NoTag(_v)
+			for (_v <- repeatedPackedField) output.writeInt32NoTag(_v)
 		}
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `requiredField`)
-		if (`optionalField`.isDefined) __size += computeFloatSize(2, `optionalField`.get)
-		if (!`repeatedPackedField`.isEmpty) {
-			val dataSize = `repeatedPackedField`.map(computeInt32SizeNoTag(_)).sum 
+		__size += computeInt32Size(1, requiredField)
+		if (optionalField.isDefined) __size += computeFloatSize(2, optionalField.get)
+		if (!repeatedPackedField.isEmpty) {
+			val dataSize = repeatedPackedField.map(computeInt32SizeNoTag(_)).sum 
 			__size += 1 + computeInt32SizeNoTag(dataSize) + dataSize
 		}
 
@@ -50,8 +50,8 @@ final case class PackedTest (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): PackedTest = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __requiredField: Int = 0
-		var __optionalField: Option[Float] = `optionalField`
-		val __repeatedPackedField: scala.collection.mutable.Buffer[Int] = `repeatedPackedField`.toBuffer
+		var __optionalField: Option[Float] = optionalField
+		val __repeatedPackedField: scala.collection.mutable.Buffer[Int] = repeatedPackedField.toBuffer
 
 		def __newMerged = PackedTest(
 			__requiredField,
@@ -77,9 +77,9 @@ final case class PackedTest (
 
 	def mergeFrom(m: PackedTest) = {
 		PackedTest(
-			m.`requiredField`,
-			m.`optionalField`.orElse(`optionalField`),
-			`repeatedPackedField` ++ m.`repeatedPackedField`
+			m.requiredField,
+			m.optionalField.orElse(optionalField),
+			repeatedPackedField ++ m.repeatedPackedField
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/RemoteProtocol.scala
+++ b/scalabuff-compiler/src/test/resources/generated/RemoteProtocol.scala
@@ -4,37 +4,37 @@
 package resources.generated
 
 final case class AkkaRemoteProtocol (
-	`message`: Option[RemoteMessageProtocol] = None,
-	`instruction`: Option[RemoteControlProtocol] = None
+	message: Option[RemoteMessageProtocol] = None,
+	instruction: Option[RemoteControlProtocol] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[AkkaRemoteProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[AkkaRemoteProtocol] {
 
-	def setMessage(_f: RemoteMessageProtocol) = copy(`message` = Some(_f))
-	def setInstruction(_f: RemoteControlProtocol) = copy(`instruction` = Some(_f))
+	def setMessage(_f: RemoteMessageProtocol) = copy(message = Some(_f))
+	def setInstruction(_f: RemoteControlProtocol) = copy(instruction = Some(_f))
 
-	def clearMessage = copy(`message` = None)
-	def clearInstruction = copy(`instruction` = None)
+	def clearMessage = copy(message = None)
+	def clearInstruction = copy(instruction = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		if (`message`.isDefined) output.writeMessage(1, `message`.get)
-		if (`instruction`.isDefined) output.writeMessage(2, `instruction`.get)
+		if (message.isDefined) output.writeMessage(1, message.get)
+		if (instruction.isDefined) output.writeMessage(2, instruction.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		if (`message`.isDefined) __size += computeMessageSize(1, `message`.get)
-		if (`instruction`.isDefined) __size += computeMessageSize(2, `instruction`.get)
+		if (message.isDefined) __size += computeMessageSize(1, message.get)
+		if (instruction.isDefined) __size += computeMessageSize(2, instruction.get)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): AkkaRemoteProtocol = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		var __message: Option[RemoteMessageProtocol] = `message`
-		var __instruction: Option[RemoteControlProtocol] = `instruction`
+		var __message: Option[RemoteMessageProtocol] = message
+		var __instruction: Option[RemoteControlProtocol] = instruction
 
 		def __newMerged = AkkaRemoteProtocol(
 			__message,
@@ -57,8 +57,8 @@ final case class AkkaRemoteProtocol (
 
 	def mergeFrom(m: AkkaRemoteProtocol) = {
 		AkkaRemoteProtocol(
-			m.`message`.orElse(`message`),
-			m.`instruction`.orElse(`instruction`)
+			m.message.orElse(message),
+			m.instruction.orElse(instruction)
 		)
 	}
 
@@ -103,38 +103,38 @@ object AkkaRemoteProtocol {
 
 }
 final case class RemoteMessageProtocol (
-	`recipient`: ActorRefProtocol = ActorRefProtocol.defaultInstance,
-	`message`: MessageProtocol = MessageProtocol.defaultInstance,
-	`sender`: Option[ActorRefProtocol] = None,
-	`metadata`: scala.collection.immutable.Seq[MetadataEntryProtocol] = Vector.empty[MetadataEntryProtocol]
+	recipient: ActorRefProtocol = ActorRefProtocol.defaultInstance,
+	message: MessageProtocol = MessageProtocol.defaultInstance,
+	sender: Option[ActorRefProtocol] = None,
+	metadata: scala.collection.immutable.Seq[MetadataEntryProtocol] = Vector.empty[MetadataEntryProtocol]
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[RemoteMessageProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[RemoteMessageProtocol] {
 
-	def setSender(_f: ActorRefProtocol) = copy(`sender` = Some(_f))
-	def setMetadata(_i: Int, _v: MetadataEntryProtocol) = copy(`metadata` = `metadata`.updated(_i, _v))
-	def addMetadata(_f: MetadataEntryProtocol) = copy(`metadata` = `metadata` :+ _f)
-	def addAllMetadata(_f: MetadataEntryProtocol*) = copy(`metadata` = `metadata` ++ _f)
-	def addAllMetadata(_f: TraversableOnce[MetadataEntryProtocol]) = copy(`metadata` = `metadata` ++ _f)
+	def setSender(_f: ActorRefProtocol) = copy(sender = Some(_f))
+	def setMetadata(_i: Int, _v: MetadataEntryProtocol) = copy(metadata = metadata.updated(_i, _v))
+	def addMetadata(_f: MetadataEntryProtocol) = copy(metadata = metadata :+ _f)
+	def addAllMetadata(_f: MetadataEntryProtocol*) = copy(metadata = metadata ++ _f)
+	def addAllMetadata(_f: TraversableOnce[MetadataEntryProtocol]) = copy(metadata = metadata ++ _f)
 
-	def clearSender = copy(`sender` = None)
-	def clearMetadata = copy(`metadata` = Vector.empty[MetadataEntryProtocol])
+	def clearSender = copy(sender = None)
+	def clearMetadata = copy(metadata = Vector.empty[MetadataEntryProtocol])
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `recipient`)
-		output.writeMessage(2, `message`)
-		if (`sender`.isDefined) output.writeMessage(4, `sender`.get)
-		for (_v <- `metadata`) output.writeMessage(5, _v)
+		output.writeMessage(1, recipient)
+		output.writeMessage(2, message)
+		if (sender.isDefined) output.writeMessage(4, sender.get)
+		for (_v <- metadata) output.writeMessage(5, _v)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `recipient`)
-		__size += computeMessageSize(2, `message`)
-		if (`sender`.isDefined) __size += computeMessageSize(4, `sender`.get)
-		for (_v <- `metadata`) __size += computeMessageSize(5, _v)
+		__size += computeMessageSize(1, recipient)
+		__size += computeMessageSize(2, message)
+		if (sender.isDefined) __size += computeMessageSize(4, sender.get)
+		for (_v <- metadata) __size += computeMessageSize(5, _v)
 
 		__size
 	}
@@ -143,8 +143,8 @@ final case class RemoteMessageProtocol (
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __recipient: ActorRefProtocol = ActorRefProtocol.defaultInstance
 		var __message: MessageProtocol = MessageProtocol.defaultInstance
-		var __sender: Option[ActorRefProtocol] = `sender`
-		val __metadata: scala.collection.mutable.Buffer[MetadataEntryProtocol] = `metadata`.toBuffer
+		var __sender: Option[ActorRefProtocol] = sender
+		val __metadata: scala.collection.mutable.Buffer[MetadataEntryProtocol] = metadata.toBuffer
 
 		def __newMerged = RemoteMessageProtocol(
 			__recipient,
@@ -168,10 +168,10 @@ final case class RemoteMessageProtocol (
 
 	def mergeFrom(m: RemoteMessageProtocol) = {
 		RemoteMessageProtocol(
-			m.`recipient`,
-			m.`message`,
-			m.`sender`.orElse(`sender`),
-			`metadata` ++ m.`metadata`
+			m.recipient,
+			m.message,
+			m.sender.orElse(sender),
+			metadata ++ m.metadata
 		)
 	}
 
@@ -220,32 +220,32 @@ object RemoteMessageProtocol {
 
 }
 final case class RemoteControlProtocol (
-	`commandType`: CommandType.EnumVal = CommandType._UNINITIALIZED,
-	`cookie`: Option[String] = None,
-	`origin`: Option[AddressProtocol] = None
+	commandType: CommandType.EnumVal = CommandType._UNINITIALIZED,
+	cookie: Option[String] = None,
+	origin: Option[AddressProtocol] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[RemoteControlProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[RemoteControlProtocol] {
 
-	def setCookie(_f: String) = copy(`cookie` = Some(_f))
-	def setOrigin(_f: AddressProtocol) = copy(`origin` = Some(_f))
+	def setCookie(_f: String) = copy(cookie = Some(_f))
+	def setOrigin(_f: AddressProtocol) = copy(origin = Some(_f))
 
-	def clearCookie = copy(`cookie` = None)
-	def clearOrigin = copy(`origin` = None)
+	def clearCookie = copy(cookie = None)
+	def clearOrigin = copy(origin = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeEnum(1, `commandType`)
-		if (`cookie`.isDefined) output.writeString(2, `cookie`.get)
-		if (`origin`.isDefined) output.writeMessage(3, `origin`.get)
+		output.writeEnum(1, commandType)
+		if (cookie.isDefined) output.writeString(2, cookie.get)
+		if (origin.isDefined) output.writeMessage(3, origin.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeEnumSize(1, `commandType`)
-		if (`cookie`.isDefined) __size += computeStringSize(2, `cookie`.get)
-		if (`origin`.isDefined) __size += computeMessageSize(3, `origin`.get)
+		__size += computeEnumSize(1, commandType)
+		if (cookie.isDefined) __size += computeStringSize(2, cookie.get)
+		if (origin.isDefined) __size += computeMessageSize(3, origin.get)
 
 		__size
 	}
@@ -253,8 +253,8 @@ final case class RemoteControlProtocol (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): RemoteControlProtocol = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __commandType: CommandType.EnumVal = CommandType._UNINITIALIZED
-		var __cookie: Option[String] = `cookie`
-		var __origin: Option[AddressProtocol] = `origin`
+		var __cookie: Option[String] = cookie
+		var __origin: Option[AddressProtocol] = origin
 
 		def __newMerged = RemoteControlProtocol(
 			__commandType,
@@ -276,9 +276,9 @@ final case class RemoteControlProtocol (
 
 	def mergeFrom(m: RemoteControlProtocol) = {
 		RemoteControlProtocol(
-			m.`commandType`,
-			m.`cookie`.orElse(`cookie`),
-			m.`origin`.orElse(`origin`)
+			m.commandType,
+			m.cookie.orElse(cookie),
+			m.origin.orElse(origin)
 		)
 	}
 
@@ -347,7 +347,7 @@ object CommandType extends net.sandrogrzicic.scalabuff.Enum {
 	}
 }
 final case class ActorRefProtocol (
-	`path`: String = ""
+	path: String = ""
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[ActorRefProtocol]
@@ -356,13 +356,13 @@ final case class ActorRefProtocol (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `path`)
+		output.writeString(1, path)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `path`)
+		__size += computeStringSize(1, path)
 
 		__size
 	}
@@ -384,7 +384,7 @@ final case class ActorRefProtocol (
 
 	def mergeFrom(m: ActorRefProtocol) = {
 		ActorRefProtocol(
-			m.`path`
+			m.path
 		)
 	}
 
@@ -427,30 +427,30 @@ object ActorRefProtocol {
 
 }
 final case class MessageProtocol (
-	`message`: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY,
-	`serializerId`: Int = 0,
-	`messageManifest`: Option[com.google.protobuf.ByteString] = None
+	message: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY,
+	serializerId: Int = 0,
+	messageManifest: Option[com.google.protobuf.ByteString] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[MessageProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[MessageProtocol] {
 
-	def setMessageManifest(_f: com.google.protobuf.ByteString) = copy(`messageManifest` = Some(_f))
+	def setMessageManifest(_f: com.google.protobuf.ByteString) = copy(messageManifest = Some(_f))
 
-	def clearMessageManifest = copy(`messageManifest` = None)
+	def clearMessageManifest = copy(messageManifest = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeBytes(1, `message`)
-		output.writeInt32(2, `serializerId`)
-		if (`messageManifest`.isDefined) output.writeBytes(3, `messageManifest`.get)
+		output.writeBytes(1, message)
+		output.writeInt32(2, serializerId)
+		if (messageManifest.isDefined) output.writeBytes(3, messageManifest.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeBytesSize(1, `message`)
-		__size += computeInt32Size(2, `serializerId`)
-		if (`messageManifest`.isDefined) __size += computeBytesSize(3, `messageManifest`.get)
+		__size += computeBytesSize(1, message)
+		__size += computeInt32Size(2, serializerId)
+		if (messageManifest.isDefined) __size += computeBytesSize(3, messageManifest.get)
 
 		__size
 	}
@@ -459,7 +459,7 @@ final case class MessageProtocol (
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __message: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY
 		var __serializerId: Int = 0
-		var __messageManifest: Option[com.google.protobuf.ByteString] = `messageManifest`
+		var __messageManifest: Option[com.google.protobuf.ByteString] = messageManifest
 
 		def __newMerged = MessageProtocol(
 			__message,
@@ -478,9 +478,9 @@ final case class MessageProtocol (
 
 	def mergeFrom(m: MessageProtocol) = {
 		MessageProtocol(
-			m.`message`,
-			m.`serializerId`,
-			m.`messageManifest`.orElse(`messageManifest`)
+			m.message,
+			m.serializerId,
+			m.messageManifest.orElse(messageManifest)
 		)
 	}
 
@@ -527,8 +527,8 @@ object MessageProtocol {
 
 }
 final case class MetadataEntryProtocol (
-	`key`: String = "",
-	`value`: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY
+	key: String = "",
+	value: com.google.protobuf.ByteString = com.google.protobuf.ByteString.EMPTY
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[MetadataEntryProtocol]
@@ -537,15 +537,15 @@ final case class MetadataEntryProtocol (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `key`)
-		output.writeBytes(2, `value`)
+		output.writeString(1, key)
+		output.writeBytes(2, value)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `key`)
-		__size += computeBytesSize(2, `value`)
+		__size += computeStringSize(1, key)
+		__size += computeBytesSize(2, value)
 
 		__size
 	}
@@ -570,8 +570,8 @@ final case class MetadataEntryProtocol (
 
 	def mergeFrom(m: MetadataEntryProtocol) = {
 		MetadataEntryProtocol(
-			m.`key`,
-			m.`value`
+			m.key,
+			m.value
 		)
 	}
 
@@ -616,9 +616,9 @@ object MetadataEntryProtocol {
 
 }
 final case class AddressProtocol (
-	`system`: String = "",
-	`hostname`: String = "",
-	`port`: Int = 0
+	system: String = "",
+	hostname: String = "",
+	port: Int = 0
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[AddressProtocol]
@@ -627,17 +627,17 @@ final case class AddressProtocol (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `system`)
-		output.writeString(2, `hostname`)
-		output.writeUInt32(3, `port`)
+		output.writeString(1, system)
+		output.writeString(2, hostname)
+		output.writeUInt32(3, port)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `system`)
-		__size += computeStringSize(2, `hostname`)
-		__size += computeUInt32Size(3, `port`)
+		__size += computeStringSize(1, system)
+		__size += computeStringSize(2, hostname)
+		__size += computeUInt32Size(3, port)
 
 		__size
 	}
@@ -665,9 +665,9 @@ final case class AddressProtocol (
 
 	def mergeFrom(m: AddressProtocol) = {
 		AddressProtocol(
-			m.`system`,
-			m.`hostname`,
-			m.`port`
+			m.system,
+			m.hostname,
+			m.port
 		)
 	}
 
@@ -714,10 +714,10 @@ object AddressProtocol {
 
 }
 final case class DaemonMsgCreateProtocol (
-	`props`: PropsProtocol = PropsProtocol.defaultInstance,
-	`deploy`: DeployProtocol = DeployProtocol.defaultInstance,
-	`path`: String = "",
-	`supervisor`: ActorRefProtocol = ActorRefProtocol.defaultInstance
+	props: PropsProtocol = PropsProtocol.defaultInstance,
+	deploy: DeployProtocol = DeployProtocol.defaultInstance,
+	path: String = "",
+	supervisor: ActorRefProtocol = ActorRefProtocol.defaultInstance
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[DaemonMsgCreateProtocol]
@@ -726,19 +726,19 @@ final case class DaemonMsgCreateProtocol (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeMessage(1, `props`)
-		output.writeMessage(2, `deploy`)
-		output.writeString(3, `path`)
-		output.writeMessage(4, `supervisor`)
+		output.writeMessage(1, props)
+		output.writeMessage(2, deploy)
+		output.writeString(3, path)
+		output.writeMessage(4, supervisor)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeMessageSize(1, `props`)
-		__size += computeMessageSize(2, `deploy`)
-		__size += computeStringSize(3, `path`)
-		__size += computeMessageSize(4, `supervisor`)
+		__size += computeMessageSize(1, props)
+		__size += computeMessageSize(2, deploy)
+		__size += computeStringSize(3, path)
+		__size += computeMessageSize(4, supervisor)
 
 		__size
 	}
@@ -769,10 +769,10 @@ final case class DaemonMsgCreateProtocol (
 
 	def mergeFrom(m: DaemonMsgCreateProtocol) = {
 		DaemonMsgCreateProtocol(
-			m.`props`,
-			m.`deploy`,
-			m.`path`,
-			m.`supervisor`
+			m.props,
+			m.deploy,
+			m.path,
+			m.supervisor
 		)
 	}
 
@@ -821,40 +821,40 @@ object DaemonMsgCreateProtocol {
 
 }
 final case class PropsProtocol (
-	`dispatcher`: String = "",
-	`deploy`: DeployProtocol = DeployProtocol.defaultInstance,
-	`fromClassCreator`: Option[String] = None,
-	`creator`: Option[com.google.protobuf.ByteString] = None,
-	`routerConfig`: Option[com.google.protobuf.ByteString] = None
+	dispatcher: String = "",
+	deploy: DeployProtocol = DeployProtocol.defaultInstance,
+	fromClassCreator: Option[String] = None,
+	creator: Option[com.google.protobuf.ByteString] = None,
+	routerConfig: Option[com.google.protobuf.ByteString] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[PropsProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[PropsProtocol] {
 
-	def setFromClassCreator(_f: String) = copy(`fromClassCreator` = Some(_f))
-	def setCreator(_f: com.google.protobuf.ByteString) = copy(`creator` = Some(_f))
-	def setRouterConfig(_f: com.google.protobuf.ByteString) = copy(`routerConfig` = Some(_f))
+	def setFromClassCreator(_f: String) = copy(fromClassCreator = Some(_f))
+	def setCreator(_f: com.google.protobuf.ByteString) = copy(creator = Some(_f))
+	def setRouterConfig(_f: com.google.protobuf.ByteString) = copy(routerConfig = Some(_f))
 
-	def clearFromClassCreator = copy(`fromClassCreator` = None)
-	def clearCreator = copy(`creator` = None)
-	def clearRouterConfig = copy(`routerConfig` = None)
+	def clearFromClassCreator = copy(fromClassCreator = None)
+	def clearCreator = copy(creator = None)
+	def clearRouterConfig = copy(routerConfig = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `dispatcher`)
-		output.writeMessage(2, `deploy`)
-		if (`fromClassCreator`.isDefined) output.writeString(3, `fromClassCreator`.get)
-		if (`creator`.isDefined) output.writeBytes(4, `creator`.get)
-		if (`routerConfig`.isDefined) output.writeBytes(5, `routerConfig`.get)
+		output.writeString(1, dispatcher)
+		output.writeMessage(2, deploy)
+		if (fromClassCreator.isDefined) output.writeString(3, fromClassCreator.get)
+		if (creator.isDefined) output.writeBytes(4, creator.get)
+		if (routerConfig.isDefined) output.writeBytes(5, routerConfig.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `dispatcher`)
-		__size += computeMessageSize(2, `deploy`)
-		if (`fromClassCreator`.isDefined) __size += computeStringSize(3, `fromClassCreator`.get)
-		if (`creator`.isDefined) __size += computeBytesSize(4, `creator`.get)
-		if (`routerConfig`.isDefined) __size += computeBytesSize(5, `routerConfig`.get)
+		__size += computeStringSize(1, dispatcher)
+		__size += computeMessageSize(2, deploy)
+		if (fromClassCreator.isDefined) __size += computeStringSize(3, fromClassCreator.get)
+		if (creator.isDefined) __size += computeBytesSize(4, creator.get)
+		if (routerConfig.isDefined) __size += computeBytesSize(5, routerConfig.get)
 
 		__size
 	}
@@ -863,9 +863,9 @@ final case class PropsProtocol (
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __dispatcher: String = ""
 		var __deploy: DeployProtocol = DeployProtocol.defaultInstance
-		var __fromClassCreator: Option[String] = `fromClassCreator`
-		var __creator: Option[com.google.protobuf.ByteString] = `creator`
-		var __routerConfig: Option[com.google.protobuf.ByteString] = `routerConfig`
+		var __fromClassCreator: Option[String] = fromClassCreator
+		var __creator: Option[com.google.protobuf.ByteString] = creator
+		var __routerConfig: Option[com.google.protobuf.ByteString] = routerConfig
 
 		def __newMerged = PropsProtocol(
 			__dispatcher,
@@ -888,11 +888,11 @@ final case class PropsProtocol (
 
 	def mergeFrom(m: PropsProtocol) = {
 		PropsProtocol(
-			m.`dispatcher`,
-			m.`deploy`,
-			m.`fromClassCreator`.orElse(`fromClassCreator`),
-			m.`creator`.orElse(`creator`),
-			m.`routerConfig`.orElse(`routerConfig`)
+			m.dispatcher,
+			m.deploy,
+			m.fromClassCreator.orElse(fromClassCreator),
+			m.creator.orElse(creator),
+			m.routerConfig.orElse(routerConfig)
 		)
 	}
 
@@ -943,37 +943,37 @@ object PropsProtocol {
 
 }
 final case class DeployProtocol (
-	`path`: String = "",
-	`config`: Option[com.google.protobuf.ByteString] = None,
-	`routerConfig`: Option[com.google.protobuf.ByteString] = None,
-	`scope`: Option[com.google.protobuf.ByteString] = None
+	path: String = "",
+	config: Option[com.google.protobuf.ByteString] = None,
+	routerConfig: Option[com.google.protobuf.ByteString] = None,
+	scope: Option[com.google.protobuf.ByteString] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[DeployProtocol]
 	with net.sandrogrzicic.scalabuff.Parser[DeployProtocol] {
 
-	def setConfig(_f: com.google.protobuf.ByteString) = copy(`config` = Some(_f))
-	def setRouterConfig(_f: com.google.protobuf.ByteString) = copy(`routerConfig` = Some(_f))
-	def setScope(_f: com.google.protobuf.ByteString) = copy(`scope` = Some(_f))
+	def setConfig(_f: com.google.protobuf.ByteString) = copy(config = Some(_f))
+	def setRouterConfig(_f: com.google.protobuf.ByteString) = copy(routerConfig = Some(_f))
+	def setScope(_f: com.google.protobuf.ByteString) = copy(scope = Some(_f))
 
-	def clearConfig = copy(`config` = None)
-	def clearRouterConfig = copy(`routerConfig` = None)
-	def clearScope = copy(`scope` = None)
+	def clearConfig = copy(config = None)
+	def clearRouterConfig = copy(routerConfig = None)
+	def clearScope = copy(scope = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `path`)
-		if (`config`.isDefined) output.writeBytes(2, `config`.get)
-		if (`routerConfig`.isDefined) output.writeBytes(3, `routerConfig`.get)
-		if (`scope`.isDefined) output.writeBytes(4, `scope`.get)
+		output.writeString(1, path)
+		if (config.isDefined) output.writeBytes(2, config.get)
+		if (routerConfig.isDefined) output.writeBytes(3, routerConfig.get)
+		if (scope.isDefined) output.writeBytes(4, scope.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `path`)
-		if (`config`.isDefined) __size += computeBytesSize(2, `config`.get)
-		if (`routerConfig`.isDefined) __size += computeBytesSize(3, `routerConfig`.get)
-		if (`scope`.isDefined) __size += computeBytesSize(4, `scope`.get)
+		__size += computeStringSize(1, path)
+		if (config.isDefined) __size += computeBytesSize(2, config.get)
+		if (routerConfig.isDefined) __size += computeBytesSize(3, routerConfig.get)
+		if (scope.isDefined) __size += computeBytesSize(4, scope.get)
 
 		__size
 	}
@@ -981,9 +981,9 @@ final case class DeployProtocol (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): DeployProtocol = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __path: String = ""
-		var __config: Option[com.google.protobuf.ByteString] = `config`
-		var __routerConfig: Option[com.google.protobuf.ByteString] = `routerConfig`
-		var __scope: Option[com.google.protobuf.ByteString] = `scope`
+		var __config: Option[com.google.protobuf.ByteString] = config
+		var __routerConfig: Option[com.google.protobuf.ByteString] = routerConfig
+		var __scope: Option[com.google.protobuf.ByteString] = scope
 
 		def __newMerged = DeployProtocol(
 			__path,
@@ -1004,10 +1004,10 @@ final case class DeployProtocol (
 
 	def mergeFrom(m: DeployProtocol) = {
 		DeployProtocol(
-			m.`path`,
-			m.`config`.orElse(`config`),
-			m.`routerConfig`.orElse(`routerConfig`),
-			m.`scope`.orElse(`scope`)
+			m.path,
+			m.config.orElse(config),
+			m.routerConfig.orElse(routerConfig),
+			m.scope.orElse(scope)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/Simple.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Simple.scala
@@ -4,65 +4,65 @@
 package resources.generated
 
 final case class SimpleTest (
-	`requiredField`: Int = 0,
-	`optionalField`: Option[Float] = None,
-	`repeatedField`: scala.collection.immutable.Seq[String] = Vector.empty[String],
+	requiredField: Int = 0,
+	optionalField: Option[Float] = None,
+	repeatedField: scala.collection.immutable.Seq[String] = Vector.empty[String],
 	`type`: Option[Int] = Some(100),
-	`int32Default`: Option[Int] = Some(100),
-	`int32Negative`: Option[Int] = Some(-1),
-	`stringDefault`: Option[String] = Some("somestring"),
-	`floatDefault`: Option[Float] = Some(1.0f),
-	`floatNegative`: Option[Float] = Some(-1.0f)
+	int32Default: Option[Int] = Some(100),
+	int32Negative: Option[Int] = Some(-1),
+	stringDefault: Option[String] = Some("somestring"),
+	floatDefault: Option[Float] = Some(1.0f),
+	floatNegative: Option[Float] = Some(-1.0f)
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[SimpleTest]
 	with net.sandrogrzicic.scalabuff.Parser[SimpleTest] {
 
-	def setOptionalField(_f: Float) = copy(`optionalField` = Some(_f))
-	def setRepeatedField(_i: Int, _v: String) = copy(`repeatedField` = `repeatedField`.updated(_i, _v))
-	def addRepeatedField(_f: String) = copy(`repeatedField` = `repeatedField` :+ _f)
-	def addAllRepeatedField(_f: String*) = copy(`repeatedField` = `repeatedField` ++ _f)
-	def addAllRepeatedField(_f: TraversableOnce[String]) = copy(`repeatedField` = `repeatedField` ++ _f)
+	def setOptionalField(_f: Float) = copy(optionalField = Some(_f))
+	def setRepeatedField(_i: Int, _v: String) = copy(repeatedField = repeatedField.updated(_i, _v))
+	def addRepeatedField(_f: String) = copy(repeatedField = repeatedField :+ _f)
+	def addAllRepeatedField(_f: String*) = copy(repeatedField = repeatedField ++ _f)
+	def addAllRepeatedField(_f: TraversableOnce[String]) = copy(repeatedField = repeatedField ++ _f)
 	def setType(_f: Int) = copy(`type` = Some(_f))
-	def setInt32Default(_f: Int) = copy(`int32Default` = Some(_f))
-	def setInt32Negative(_f: Int) = copy(`int32Negative` = Some(_f))
-	def setStringDefault(_f: String) = copy(`stringDefault` = Some(_f))
-	def setFloatDefault(_f: Float) = copy(`floatDefault` = Some(_f))
-	def setFloatNegative(_f: Float) = copy(`floatNegative` = Some(_f))
+	def setInt32Default(_f: Int) = copy(int32Default = Some(_f))
+	def setInt32Negative(_f: Int) = copy(int32Negative = Some(_f))
+	def setStringDefault(_f: String) = copy(stringDefault = Some(_f))
+	def setFloatDefault(_f: Float) = copy(floatDefault = Some(_f))
+	def setFloatNegative(_f: Float) = copy(floatNegative = Some(_f))
 
-	def clearOptionalField = copy(`optionalField` = None)
-	def clearRepeatedField = copy(`repeatedField` = Vector.empty[String])
+	def clearOptionalField = copy(optionalField = None)
+	def clearRepeatedField = copy(repeatedField = Vector.empty[String])
 	def clearType = copy(`type` = None)
-	def clearInt32Default = copy(`int32Default` = None)
-	def clearInt32Negative = copy(`int32Negative` = None)
-	def clearStringDefault = copy(`stringDefault` = None)
-	def clearFloatDefault = copy(`floatDefault` = None)
-	def clearFloatNegative = copy(`floatNegative` = None)
+	def clearInt32Default = copy(int32Default = None)
+	def clearInt32Negative = copy(int32Negative = None)
+	def clearStringDefault = copy(stringDefault = None)
+	def clearFloatDefault = copy(floatDefault = None)
+	def clearFloatNegative = copy(floatNegative = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `requiredField`)
-		if (`optionalField`.isDefined) output.writeFloat(2, `optionalField`.get)
-		for (_v <- `repeatedField`) output.writeString(3, _v)
+		output.writeInt32(1, requiredField)
+		if (optionalField.isDefined) output.writeFloat(2, optionalField.get)
+		for (_v <- repeatedField) output.writeString(3, _v)
 		if (`type`.isDefined) output.writeInt32(4, `type`.get)
-		if (`int32Default`.isDefined) output.writeInt32(5, `int32Default`.get)
-		if (`int32Negative`.isDefined) output.writeInt32(6, `int32Negative`.get)
-		if (`stringDefault`.isDefined) output.writeString(7, `stringDefault`.get)
-		if (`floatDefault`.isDefined) output.writeFloat(8, `floatDefault`.get)
-		if (`floatNegative`.isDefined) output.writeFloat(9, `floatNegative`.get)
+		if (int32Default.isDefined) output.writeInt32(5, int32Default.get)
+		if (int32Negative.isDefined) output.writeInt32(6, int32Negative.get)
+		if (stringDefault.isDefined) output.writeString(7, stringDefault.get)
+		if (floatDefault.isDefined) output.writeFloat(8, floatDefault.get)
+		if (floatNegative.isDefined) output.writeFloat(9, floatNegative.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `requiredField`)
-		if (`optionalField`.isDefined) __size += computeFloatSize(2, `optionalField`.get)
-		for (_v <- `repeatedField`) __size += computeStringSize(3, _v)
+		__size += computeInt32Size(1, requiredField)
+		if (optionalField.isDefined) __size += computeFloatSize(2, optionalField.get)
+		for (_v <- repeatedField) __size += computeStringSize(3, _v)
 		if (`type`.isDefined) __size += computeInt32Size(4, `type`.get)
-		if (`int32Default`.isDefined) __size += computeInt32Size(5, `int32Default`.get)
-		if (`int32Negative`.isDefined) __size += computeInt32Size(6, `int32Negative`.get)
-		if (`stringDefault`.isDefined) __size += computeStringSize(7, `stringDefault`.get)
-		if (`floatDefault`.isDefined) __size += computeFloatSize(8, `floatDefault`.get)
-		if (`floatNegative`.isDefined) __size += computeFloatSize(9, `floatNegative`.get)
+		if (int32Default.isDefined) __size += computeInt32Size(5, int32Default.get)
+		if (int32Negative.isDefined) __size += computeInt32Size(6, int32Negative.get)
+		if (stringDefault.isDefined) __size += computeStringSize(7, stringDefault.get)
+		if (floatDefault.isDefined) __size += computeFloatSize(8, floatDefault.get)
+		if (floatNegative.isDefined) __size += computeFloatSize(9, floatNegative.get)
 
 		__size
 	}
@@ -70,14 +70,14 @@ final case class SimpleTest (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): SimpleTest = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __requiredField: Int = 0
-		var __optionalField: Option[Float] = `optionalField`
-		val __repeatedField: scala.collection.mutable.Buffer[String] = `repeatedField`.toBuffer
+		var __optionalField: Option[Float] = optionalField
+		val __repeatedField: scala.collection.mutable.Buffer[String] = repeatedField.toBuffer
 		var __type: Option[Int] = `type`
-		var __int32Default: Option[Int] = `int32Default`
-		var __int32Negative: Option[Int] = `int32Negative`
-		var __stringDefault: Option[String] = `stringDefault`
-		var __floatDefault: Option[Float] = `floatDefault`
-		var __floatNegative: Option[Float] = `floatNegative`
+		var __int32Default: Option[Int] = int32Default
+		var __int32Negative: Option[Int] = int32Negative
+		var __stringDefault: Option[String] = stringDefault
+		var __floatDefault: Option[Float] = floatDefault
+		var __floatNegative: Option[Float] = floatNegative
 
 		def __newMerged = SimpleTest(
 			__requiredField,
@@ -108,15 +108,15 @@ final case class SimpleTest (
 
 	def mergeFrom(m: SimpleTest) = {
 		SimpleTest(
-			m.`requiredField`,
-			m.`optionalField`.orElse(`optionalField`),
-			`repeatedField` ++ m.`repeatedField`,
+			m.requiredField,
+			m.optionalField.orElse(optionalField),
+			repeatedField ++ m.repeatedField,
 			m.`type`.orElse(`type`),
-			m.`int32Default`.orElse(`int32Default`),
-			m.`int32Negative`.orElse(`int32Negative`),
-			m.`stringDefault`.orElse(`stringDefault`),
-			m.`floatDefault`.orElse(`floatDefault`),
-			m.`floatNegative`.orElse(`floatNegative`)
+			m.int32Default.orElse(int32Default),
+			m.int32Negative.orElse(int32Negative),
+			m.stringDefault.orElse(stringDefault),
+			m.floatDefault.orElse(floatDefault),
+			m.floatNegative.orElse(floatNegative)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/SimpleWithComments.scala
+++ b/scalabuff-compiler/src/test/resources/generated/SimpleWithComments.scala
@@ -4,32 +4,32 @@
 package resources.generated
 
 final case class SimpleRequest (
-	`query`: String = "",
-	`pageNumber`: Option[Int] = None,
-	`resultsPerPage`: Option[Int] = None
+	query: String = "",
+	pageNumber: Option[Int] = None,
+	resultsPerPage: Option[Int] = None
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[SimpleRequest]
 	with net.sandrogrzicic.scalabuff.Parser[SimpleRequest] {
 
-	def setPageNumber(_f: Int) = copy(`pageNumber` = Some(_f))
-	def setResultsPerPage(_f: Int) = copy(`resultsPerPage` = Some(_f))
+	def setPageNumber(_f: Int) = copy(pageNumber = Some(_f))
+	def setResultsPerPage(_f: Int) = copy(resultsPerPage = Some(_f))
 
-	def clearPageNumber = copy(`pageNumber` = None)
-	def clearResultsPerPage = copy(`resultsPerPage` = None)
+	def clearPageNumber = copy(pageNumber = None)
+	def clearResultsPerPage = copy(resultsPerPage = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeString(1, `query`)
-		if (`pageNumber`.isDefined) output.writeInt32(2, `pageNumber`.get)
-		if (`resultsPerPage`.isDefined) output.writeInt32(3, `resultsPerPage`.get)
+		output.writeString(1, query)
+		if (pageNumber.isDefined) output.writeInt32(2, pageNumber.get)
+		if (resultsPerPage.isDefined) output.writeInt32(3, resultsPerPage.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeStringSize(1, `query`)
-		if (`pageNumber`.isDefined) __size += computeInt32Size(2, `pageNumber`.get)
-		if (`resultsPerPage`.isDefined) __size += computeInt32Size(3, `resultsPerPage`.get)
+		__size += computeStringSize(1, query)
+		if (pageNumber.isDefined) __size += computeInt32Size(2, pageNumber.get)
+		if (resultsPerPage.isDefined) __size += computeInt32Size(3, resultsPerPage.get)
 
 		__size
 	}
@@ -37,8 +37,8 @@ final case class SimpleRequest (
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): SimpleRequest = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
 		var __query: String = ""
-		var __pageNumber: Option[Int] = `pageNumber`
-		var __resultsPerPage: Option[Int] = `resultsPerPage`
+		var __pageNumber: Option[Int] = pageNumber
+		var __resultsPerPage: Option[Int] = resultsPerPage
 
 		def __newMerged = SimpleRequest(
 			__query,
@@ -57,9 +57,9 @@ final case class SimpleRequest (
 
 	def mergeFrom(m: SimpleRequest) = {
 		SimpleRequest(
-			m.`query`,
-			m.`pageNumber`.orElse(`pageNumber`),
-			m.`resultsPerPage`.orElse(`resultsPerPage`)
+			m.query,
+			m.pageNumber.orElse(pageNumber),
+			m.resultsPerPage.orElse(resultsPerPage)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/Singlequoted.scala
+++ b/scalabuff-compiler/src/test/resources/generated/Singlequoted.scala
@@ -4,31 +4,31 @@
 package resources.generated
 
 final case class SingleQuote (
-	`singleQuotedField`: Option[String] = Some("NA")
+	singleQuotedField: Option[String] = Some("NA")
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[SingleQuote]
 	with net.sandrogrzicic.scalabuff.Parser[SingleQuote] {
 
-	def setSingleQuotedField(_f: String) = copy(`singleQuotedField` = Some(_f))
+	def setSingleQuotedField(_f: String) = copy(singleQuotedField = Some(_f))
 
-	def clearSingleQuotedField = copy(`singleQuotedField` = None)
+	def clearSingleQuotedField = copy(singleQuotedField = None)
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		if (`singleQuotedField`.isDefined) output.writeString(1, `singleQuotedField`.get)
+		if (singleQuotedField.isDefined) output.writeString(1, singleQuotedField.get)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		if (`singleQuotedField`.isDefined) __size += computeStringSize(1, `singleQuotedField`.get)
+		if (singleQuotedField.isDefined) __size += computeStringSize(1, singleQuotedField.get)
 
 		__size
 	}
 
 	def mergeFrom(in: com.google.protobuf.CodedInputStream, extensionRegistry: com.google.protobuf.ExtensionRegistryLite): SingleQuote = {
 		import com.google.protobuf.ExtensionRegistryLite.{getEmptyRegistry => _emptyRegistry}
-		var __singleQuotedField: Option[String] = `singleQuotedField`
+		var __singleQuotedField: Option[String] = singleQuotedField
 
 		def __newMerged = SingleQuote(
 			__singleQuotedField
@@ -43,7 +43,7 @@ final case class SingleQuote (
 
 	def mergeFrom(m: SingleQuote) = {
 		SingleQuote(
-			m.`singleQuotedField`.orElse(`singleQuotedField`)
+			m.singleQuotedField.orElse(singleQuotedField)
 		)
 	}
 

--- a/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
+++ b/scalabuff-compiler/src/test/resources/generated/nested/PackageName.scala
@@ -4,7 +4,7 @@
 package resources.generated.nested
 
 final case class PackageTest (
-	`requiredField`: Int = 0
+	requiredField: Int = 0
 ) extends com.google.protobuf.GeneratedMessageLite
 	with com.google.protobuf.MessageLite.Builder
 	with net.sandrogrzicic.scalabuff.Message[PackageTest]
@@ -13,13 +13,13 @@ final case class PackageTest (
 
 
 	def writeTo(output: com.google.protobuf.CodedOutputStream) {
-		output.writeInt32(1, `requiredField`)
+		output.writeInt32(1, requiredField)
 	}
 
 	def getSerializedSize = {
 		import com.google.protobuf.CodedOutputStream._
 		var __size = 0
-		__size += computeInt32Size(1, `requiredField`)
+		__size += computeInt32Size(1, requiredField)
 
 		__size
 	}
@@ -41,7 +41,7 @@ final case class PackageTest (
 
 	def mergeFrom(m: PackageTest) = {
 		PackageTest(
-			m.`requiredField`
+			m.requiredField
 		)
 	}
 
@@ -54,7 +54,18 @@ final case class PackageTest (
 	override def getParserForType = this
 	def newBuilderForType = getDefaultInstanceForType
 	def toBuilder = this
-	def toJson(indent: Int = 0): String = "ScalaBuff JSON generation not enabled. Use --generate_json_method to enable."
+	def toJson(indent: Int = 0): String = {
+		val indent0 = "\n" + ("\t" * indent)
+		val (indent1, indent2) = (indent0 + "\t", indent0 + "\t\t")
+		val sb = StringBuilder.newBuilder
+		sb
+			.append("{")
+			sb.append(indent1).append("\"requiredField\": ").append("\"").append(`requiredField`).append("\"").append(',')
+		if (sb.last.equals(',')) sb.length -= 1
+		sb.append(indent0).append("}")
+		sb.toString()
+	}
+
 }
 
 object PackageTest {


### PR DESCRIPTION
This PR is closely related to #20, and partially reverts some of the behavior.
Rather than adding backticks to *every* identifier, the change only adds them to: 
 1. reserved keywords (`type`, `val`, etc), and 
 2. invalid identifiers (things with symbols, spaces, etc - may not be needed because of .proto restrictions).

All other identifiers are left alone.

The main motivation behind this is that some IDEs (cough IntelliJ) do not do well with backticks and code completion. This makes it a real pain to write code that uses classes generated by ScalaBuff.