### PR TITLE
Add remaining scala keywords

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/BuffedString.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/BuffedString.scala
@@ -106,7 +106,11 @@ object BuffedString {
 	 * Reserved scala keywords that require backticks
 	 */
 	val scalaReserved =
-		Set("type", "val", "def", "else", "if", "object",
-			"yield", "for", "import", "match", "case", "lazy",
-			"var", "class", "package", "extends")
+		Set("abstract", "case", "catch", "class", "def", "do", "else",
+			"extends", "false", "final", "finally", "for", "forSome",
+			"if", "implicit", "import", "lazy", "macro", "match",
+			"new", "null", "object", "override", "package", "private",
+			"protected", "return", "sealed", "super", "then", "this",
+			"throw", "trait", "true", "try", "type", "val", "var",
+			"while", "with", "yield")
 }


### PR DESCRIPTION
I realized I left out a lot of keywords in #114, so I went back and generated a complete list by using Scala's reflection API ([found instructions here](http://stackoverflow.com/questions/22037430/programatically-checking-whether-a-string-is-a-reserved-word-in-scala)). I probably should've done this in the first place.