### PR TITLE
Allow extending user defined traits by adding option 'trait' to messages

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -149,6 +149,10 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
       }
       out.append('\n').append(indent1).append("with net.sandrogrzicic.scalabuff.Parser[").append(name).append("]")
 
+      for (OptionValue(_, value) <- body.options.filter(_.key == "trait")) {
+        out.append('\n').append(indent1).append("with ").append(value.replace("$name", name).stripQuotes)
+      }
+
       out.append(" {\n\n")
 
       // setters


### PR DESCRIPTION
Hi,

I wanted to extend user defined trait to mimic c# partial classes, this allows to add user defined code to generated classes, for example, this message : 

```protobuf
message IntString {

    option trait = "foo.bar";


    required int32 key = 1;
    required bytes value = 2;
}
```

with this code : 

```scala
package foo

trait bar {
  def value: Array[Byte]
  lazy val valueAsString = new String(value)
}
```

allows me to lazily parse the value to utf8 string.

I'm also replacing `$name` with the name of the generated class in case users will want to add the name of the class (for example, when using generics) : 

```protobuf
message IntString {

    option trait = "foo.bar[$name]";


    required int32 key = 1;
    required bytes value = 2;
}
```

user can add as many traits as he wants.