### PR TITLE
Add availablity to specify scala-only package name / class name

### DIFF
--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/Generator.scala
@@ -578,7 +578,9 @@ class Generator protected (sourceName: String, importedSymbols: Map[String, Impo
             case ImportStatement(name)  => imports += name
             case PackageStatement(name) => if (packageName.isEmpty) packageName = name
             case OptionValue(key, value) => key match {
+              case "scala_package"        => packageName = value.stripQuotes
               case "java_package"         => packageName = value.stripQuotes
+              case "scala_outer_classname" => className = value.stripQuotes
               case "java_outer_classname" => className = value.stripQuotes
               case "lazy_compute_serialized_size" => value match {
                 case "true"         => lazyGetSerializedSize = true

--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/compiler/ScalaBuff.scala
@@ -64,7 +64,8 @@ object ScalaBuff {
     def dig(name: String): List[(String, ImportedSymbol)] = {
       val tree = parse(searchPath(name).getOrElse { throw new IOException("Unable to import: " + name) })
       val packageName = tree.collectFirst {
-        case OptionValue(key, value) if key == "java_package" => value.stripQuotes
+        case OptionValue("scala_package", value) => value.stripQuotes
+        case OptionValue("java_package", value)  => value.stripQuotes
       }.getOrElse("")
       val protoPackage = tree.collectFirst {
         case PackageStatement(name) => name

--- a/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/test/UpdateTestResources.scala
+++ b/scalabuff-compiler/src/main/net/sandrogrzicic/scalabuff/test/UpdateTestResources.scala
@@ -70,7 +70,10 @@ object UpdateTestResources extends App {
 	// if we have a valid parsing tree, generate a Scala proto class.
 
         // for now, this is hard-coded.
-        val importedSymbols = Map("PackageTest" -> ImportedSymbol("nested", isEnum = false))
+        val importedSymbols = Map(
+					"PackageTest" -> ImportedSymbol("nested", isEnum = false),
+					"PackageScalaTest" -> ImportedSymbol("nested_scala", isEnum = false)
+				)
 
         val generated = Generator(parsed, file.getName, importedSymbols, generateJsonMethod = true, None)
 	val generatedPath = testDir + generated.path + generated.file + ".scala"

--- a/scalabuff-compiler/src/test/resources/parsed/PackageScalaName.txt
+++ b/scalabuff-compiler/src/test/resources/parsed/PackageScalaName.txt
@@ -1,0 +1,1 @@
+List(PackageStatement(resources.generated.nested), OptionValue(java_package,"resources.generated.nested"), OptionValue(scala_package,"resources.generated.nested_scala"), Message(PackageScalaTest,MessageBody(List(Field(required,Int32,required_field,1,List(),)),List(),List(),List(),List(),List(),List())))

--- a/scalabuff-compiler/src/test/resources/proto/package_scala_name.proto
+++ b/scalabuff-compiler/src/test/resources/proto/package_scala_name.proto
@@ -1,0 +1,8 @@
+package resources.generated.nested;
+
+option java_package = "resources.generated.nested";
+option scala_package = "resources.generated.nested_scala";
+
+message PackageScalaTest {
+  required int32 required_field = 1;
+}


### PR DESCRIPTION
Sometimes you need to have scala & java version of protobuf classes. In my case it's because I need to have human input / output format and only Java version of protobuf objects implements MessageOrBuilder interface that allows you to have pretty printing via google TextFormat class)

So since java_package option is used by java compiler as well, we gonna have separate option for scala (scala_package and scala_outer_classname)

Test is provided as well.
